### PR TITLE
[MISC] Add robinhood library.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/seqan3
 	url = https://github.com/seqan/seqan3
 	branch = master
+[submodule "lib/robin-hood-hashing"]
+	path = lib/robin-hood-hashing
+	url = https://github.com/martinus/robin-hood-hashing.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ string (ASCII 27 Esc)
 set (FontBold "${Esc}[1m")
 set (FontReset "${Esc}[m")
 
+# Dependency: robin_hood
+add_subdirectory(lib/robin-hood-hashing)
+
 # Dependency: SeqAn3.
 find_package (SeqAn3 QUIET REQUIRED HINTS lib/seqan3/build_system)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required (VERSION 3.8)
 # raptor build
 add_library ("${PROJECT_NAME}_build_lib" STATIC raptor_build.cpp)
 target_link_libraries ("${PROJECT_NAME}_build_lib" PUBLIC seqan3::seqan3)
+target_link_libraries ("${PROJECT_NAME}_build_lib" PUBLIC robin_hood)
 target_include_directories ("${PROJECT_NAME}_build_lib" PUBLIC ../include)
 
 # the minimiser model will be used for raptor search

--- a/src/raptor_build.cpp
+++ b/src/raptor_build.cpp
@@ -1,4 +1,5 @@
 #include <seqan3/std/charconv>
+#include <robin_hood.h>
 
 #include <seqan3/argument_parser/all.hpp>
 #include <seqan3/core/algorithm/detail/execution_handler_parallel.hpp>
@@ -196,7 +197,7 @@ inline void compute_minimisers(build_arguments const & arguments)
 
     auto worker = [&] (auto && zipped_view, auto &&)
         {
-            std::unordered_map<uint64_t, uint8_t> minimiser_table{};
+            robin_hood::unordered_map<uint64_t, uint8_t> minimiser_table{};
             uint64_t count{0};
             uint16_t cutoff{default_cutoff};
 


### PR DESCRIPTION
Add robin hood to improve speed.
Tested with one fastq.gz file of size 1.6 GB and timed with /usr/bin/time -v

without robinhood
```
User time (seconds): 232.17
	System time (seconds): 1.60
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:53.83
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 2258412
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 444485
	Voluntary context switches: 17
	Involuntary context switches: 390
	Swaps: 0
	File system inputs: 0
	File system outputs: 66336
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

with robin hood
```
User time (seconds): 144.07
	System time (seconds): 1.16
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:25.28
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 3349820
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 10657
	Voluntary context switches: 18
	Involuntary context switches: 199
	Swaps: 0
	File system inputs: 0
	File system outputs: 66336
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

```