### PR TITLE
[FIX] default help page message for --window

### DIFF
--- a/include/raptor/argument_parsing/build_arguments.hpp
+++ b/include/raptor/argument_parsing/build_arguments.hpp
@@ -12,14 +12,17 @@
 
 #include <seqan3/search/kmer_index/shape.hpp>
 
+#include <raptor/strong_types.hpp>
+
 namespace raptor
 {
 
 struct build_arguments
 {
     // Related to k-mers
-    uint32_t window_size{0u};
     uint8_t kmer_size{20u};
+    uint32_t window_size{kmer_size};
+    window window_size_strong{kmer_size};
     std::string shape_string{};
     seqan3::shape shape{seqan3::ungapped{kmer_size}};
     bool compute_minimiser{false};

--- a/include/raptor/argument_parsing/validators.hpp
+++ b/include/raptor/argument_parsing/validators.hpp
@@ -10,6 +10,8 @@
 #include <seqan3/argument_parser/argument_parser.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
 
+#include <raptor/strong_types.hpp>
+
 namespace raptor
 {
 
@@ -42,6 +44,11 @@ public:
     ~positive_integer_validator() = default;
 
     explicit positive_integer_validator(bool const is_zero_positive_) : is_zero_positive{is_zero_positive_} {}
+
+    void operator()(window const & val) const
+    {
+        return operator()(val.v);
+    }
 
     void operator()(option_value_type const & val) const
     {

--- a/include/raptor/strong_types.hpp
+++ b/include/raptor/strong_types.hpp
@@ -13,6 +13,9 @@ namespace raptor
 {
 
 //!\brief Strong type for passing the window size.
-struct window { uint64_t v; };
+struct window
+{
+    uint32_t v{};
+};
 
 } // namespace raptor

--- a/src/argument_parsing/build_parsing.cpp
+++ b/src/argument_parsing/build_parsing.cpp
@@ -14,6 +14,18 @@
 namespace raptor
 {
 
+// Printing a custom default value for argument_parser.
+std::ostream & operator<<(std::ostream & s, window const &)
+{
+    return s << "\\fBk-mer size\\fP";
+}
+
+// Parsing input from argument_parser.
+std::istream & operator>>(std::istream & s, window & window_)
+{
+    return s >> window_.v;
+}
+
 void init_build_parser(seqan3::argument_parser & parser, build_arguments & arguments)
 {
     init_shared_meta(parser);
@@ -30,18 +42,18 @@ void init_build_parser(seqan3::argument_parser & parser, build_arguments & argum
                       "Splits the index in this many parts.",
                       arguments.is_socks ? seqan3::option_spec::hidden : seqan3::option_spec::standard,
                       power_of_two_validator{});
-    parser.add_option(arguments.window_size,
-                      '\0',
-                      "window",
-                      "The window size. \\fI\\fBIf not set, defaults to the k-mer size.\\fP",
-                      arguments.is_socks ? seqan3::option_spec::hidden : seqan3::option_spec::standard,
-                      positive_integer_validator{});
     parser.add_option(arguments.kmer_size,
                       '\0',
                       "kmer",
                       "The k-mer size.", // Mutually exclusive with --shape.
                       seqan3::option_spec::standard,
                       seqan3::arithmetic_range_validator{1, 32});
+    parser.add_option(arguments.window_size_strong,
+                      '\0',
+                      "window",
+                      "The window size.",
+                      arguments.is_socks ? seqan3::option_spec::hidden : seqan3::option_spec::standard,
+                      positive_integer_validator{});
     parser.add_option(arguments.shape_string,
                       '\0',
                       "shape",
@@ -135,6 +147,7 @@ void build_parsing(seqan3::argument_parser & parser, bool const is_socks)
 
     if (parser.is_option_set("window"))
     {
+        arguments.window_size = arguments.window_size_strong.v;
         if (arguments.shape.size() > arguments.window_size)
             throw seqan3::argument_parser_error{"The k-mer size cannot be bigger than the window size."};
     }

--- a/src/search/detail/destroyed_indirectly_by_error.cpp
+++ b/src/search/detail/destroyed_indirectly_by_error.cpp
@@ -43,7 +43,7 @@ std::vector<double> destroyed_indirectly_by_error(size_t const pattern_size,
         for (size_t i = 0; i < pattern_size; ++i)
             sequence.push_back(seqan3::assign_rank_to(dis(gen), alphabet_t{}));
 
-        forward_strand_minimiser mini{window{window_size}, shape};
+        forward_strand_minimiser mini{window{static_cast<uint32_t>(window_size)}, shape};
         mini.compute(sequence);
         for (auto x : mini.minimiser_begin)
             mins[x] = true;


### PR DESCRIPTION
Better solution for https://github.com/seqan/raptor/issues/79

```
    --kmer (unsigned 8 bit integer)
          The k-mer size. Default: 20. Value must be in range [1,32].
    --window (raptor::window)
          The window size. Default: k-mer size. Value must be a positive integer.
```