### PR TITLE
[PATCH] removes strong types

### DIFF
--- a/include/raptor/argument_parsing/build_arguments.hpp
+++ b/include/raptor/argument_parsing/build_arguments.hpp
@@ -22,7 +22,6 @@ struct build_arguments
     // Related to k-mers
     uint8_t kmer_size{20u};
     uint32_t window_size{kmer_size};
-    window window_size_strong{kmer_size};
     std::string shape_string{};
     seqan3::shape shape{seqan3::ungapped{kmer_size}};
     bool compute_minimiser{false};

--- a/include/raptor/argument_parsing/search_arguments.hpp
+++ b/include/raptor/argument_parsing/search_arguments.hpp
@@ -17,12 +17,6 @@
 namespace raptor
 {
 
-// For costum default message in argparser
-struct pattern_size
-{
-    uint64_t v{};
-};
-
 struct search_arguments
 {
     // Related to k-mers
@@ -39,7 +33,6 @@ struct search_arguments
     double p_max{0.15};
     double fpr{0.05};
     uint64_t pattern_size{};
-    raptor::pattern_size pattern_size_strong{};
     uint8_t errors{0};
 
     // Related to IBF

--- a/include/raptor/argument_parsing/validators.hpp
+++ b/include/raptor/argument_parsing/validators.hpp
@@ -83,11 +83,6 @@ public:
     explicit positive_integer_validator(bool const is_zero_positive_) : is_zero_positive{is_zero_positive_}
     {}
 
-    void operator()(window const & val) const
-    {
-        return operator()(val.v);
-    }
-
     void operator()(option_value_type const & val) const
     {
         if (!is_zero_positive && !val)

--- a/src/argument_parsing/search_parsing.cpp
+++ b/src/argument_parsing/search_parsing.cpp
@@ -17,18 +17,6 @@
 namespace raptor
 {
 
-// Printing a custom default value for argument_parser.
-std::ostream & operator<<(std::ostream & s, pattern_size const &)
-{
-    return s << "Median of sequence lengths in query file";
-}
-
-// Parsing input from argument_parser.
-std::istream & operator>>(std::istream & s, pattern_size & pattern_size_)
-{
-    return s >> pattern_size_.v;
-}
-
 void init_search_parser(sharg::parser & parser, search_arguments & arguments)
 {
     init_shared_meta(parser);
@@ -87,10 +75,11 @@ void init_search_parser(sharg::parser & parser, search_arguments & arguments)
                                     .description = "The false positive rate used for building the index.",
                                     .hidden = arguments.is_socks,
                                     .validator = sharg::arithmetic_range_validator{0, 1}});
-    parser.add_option(arguments.pattern_size_strong,
+    parser.add_option(arguments.pattern_size,
                       sharg::config{.short_id = '\0',
                                     .long_id = "pattern",
                                     .description = "The pattern size.",
+                                    .default_message = "Median of sequence lengths in query file",
                                     .hidden = arguments.is_socks});
     parser.add_option(arguments.threads,
                       sharg::config{.short_id = '\0',
@@ -171,10 +160,6 @@ void search_parsing(sharg::parser & parser, bool const is_socks)
             }
             std::sort(sequence_lengths.begin(), sequence_lengths.end());
             arguments.pattern_size = sequence_lengths[sequence_lengths.size() / 2];
-        }
-        else
-        {
-            arguments.pattern_size = arguments.pattern_size_strong.v;
         }
     }
 


### PR DESCRIPTION
This replaces the strong window type with the new `default_message` functionality of sharg-parser.

There is still one todo, seems like an overspecified concept in sharg.