### PR TITLE
[MISC] Remove complexity from build_ibf

### DIFF
--- a/include/raptor/build/build_ibf.hpp
+++ b/include/raptor/build/build_ibf.hpp
@@ -12,7 +12,6 @@
 namespace raptor
 {
 
-template <bool compressed>
 void build_ibf(build_arguments const & arguments);
 
 } // namespace raptor

--- a/include/raptor/build/index_factory.hpp
+++ b/include/raptor/build/index_factory.hpp
@@ -19,7 +19,6 @@
 namespace raptor
 {
 
-template <bool compressed>
 class index_factory
 {
 public:
@@ -48,14 +47,9 @@ public:
             reader = file_reader<file_types::sequence>{arguments->shape, arguments->window_size};
     }
 
-    [[nodiscard]] auto operator()(size_t const part = 0u) const
+    [[nodiscard]] raptor_index<> operator()(size_t const part = 0u) const
     {
-        auto tmp = construct(part);
-
-        if constexpr (!compressed)
-            return tmp;
-        else
-            return raptor_index<index_structure::ibf_compressed>{std::move(tmp)};
+        return construct(part);
     }
 
 private:
@@ -63,7 +57,7 @@ private:
     partition_config const * const config{nullptr};
     std::variant<file_reader<file_types::sequence>, file_reader<file_types::minimiser>> reader;
 
-    auto construct(size_t const part) const
+    raptor_index<> construct(size_t const part) const
     {
         assert(arguments != nullptr);
 

--- a/include/raptor/build/store_index.hpp
+++ b/include/raptor/build/store_index.hpp
@@ -17,13 +17,32 @@
 namespace raptor
 {
 
-template <typename data_t, typename arguments_t>
-static inline void
-store_index(std::filesystem::path const & path, raptor_index<data_t> const & index, arguments_t const &)
+// Compresion handled in chopper_build
+template <index_structure::is_hibf data_t, typename arguments_t>
+static inline void store_index(std::filesystem::path const & path, raptor_index<data_t> && index, arguments_t const &)
 {
     std::ofstream os{path, std::ios::binary};
     cereal::BinaryOutputArchive oarchive{os};
     oarchive(index);
+}
+
+template <index_structure::is_ibf data_t, typename arguments_t>
+static inline void
+store_index(std::filesystem::path const & path, raptor_index<data_t> && index, arguments_t const & arguments)
+{
+    if (!arguments.compressed)
+    {
+        std::ofstream os{path, std::ios::binary};
+        cereal::BinaryOutputArchive oarchive{os};
+        oarchive(index);
+    }
+    else
+    {
+        raptor_index<index_structure::ibf_compressed> compressed_index{std::move(index)};
+        std::ofstream os{path, std::ios::binary};
+        cereal::BinaryOutputArchive oarchive{os};
+        oarchive(compressed_index);
+    }
 }
 
 template <seqan3::data_layout layout, typename arguments_t>

--- a/include/raptor/index.hpp
+++ b/include/raptor/index.hpp
@@ -28,6 +28,13 @@ template <typename return_t, typename input_t>
 concept compressible_from = (std::same_as<return_t, ibf_compressed> && std::same_as<input_t, ibf>)
                          || (std::same_as<return_t, hibf_compressed> && std::same_as<input_t, hibf>);
 
+template <typename index_t>
+concept is_ibf = std::same_as<index_t, index_structure::ibf> || std::same_as<index_t, index_structure::ibf_compressed>;
+
+template <typename index_t>
+concept is_hibf =
+    std::same_as<index_t, index_structure::hibf> || std::same_as<index_t, index_structure::hibf_compressed>;
+
 } // namespace index_structure
 
 template <typename data_t = index_structure::ibf>
@@ -43,8 +50,7 @@ private:
     bool compressed_{};
     std::vector<std::vector<std::string>> bin_path_{};
     double fpr_{};
-    bool is_hibf_{std::same_as<data_t, index_structure::hibf>
-                  || std::same_as<data_t, index_structure::hibf_compressed>};
+    bool is_hibf_{index_structure::is_hibf<data_t>};
     data_t ibf_{};
 
 public:

--- a/src/build/build_ibf.cpp
+++ b/src/build/build_ibf.cpp
@@ -14,21 +14,20 @@
 namespace raptor
 {
 
-template <bool compressed>
 void build_ibf(build_arguments const & arguments)
 {
     if (arguments.parts == 1u)
     {
-        index_factory<compressed> factory{arguments};
+        index_factory factory{arguments};
         auto index = factory();
-        store_index(arguments.out_path, index, arguments);
+        store_index(arguments.out_path, std::move(index), arguments);
     }
     else
     {
         partition_config const cfg{arguments.parts};
         std::vector<size_t> const kmers_per_partition = max_count_per_partition(cfg, arguments);
         build_arguments args = arguments;
-        index_factory<compressed> factory{args, cfg};
+        index_factory factory{args, cfg};
 
         for (size_t part = 0; part < arguments.parts; ++part)
         {
@@ -36,13 +35,9 @@ void build_ibf(build_arguments const & arguments)
             auto index = factory(part);
             std::filesystem::path out_path{arguments.out_path};
             out_path += "_" + std::to_string(part);
-            store_index(out_path, index, arguments);
+            store_index(out_path, std::move(index), arguments);
         }
     }
 }
-
-template void build_ibf<false>(build_arguments const & arguments);
-
-template void build_ibf<true>(build_arguments const & arguments);
 
 } // namespace raptor

--- a/src/build/hibf/chopper_build.cpp
+++ b/src/build/hibf/chopper_build.cpp
@@ -34,7 +34,7 @@ void chopper_build(build_arguments const & arguments)
                                                                                 arguments.fpr,
                                                                                 std::move(data.hibf)};
 
-    store_index(arguments.out_path, index, arguments);
+    store_index(arguments.out_path, std::move(index), arguments);
 }
 
 template void chopper_build<seqan3::data_layout::uncompressed>(build_arguments const &);

--- a/src/build/raptor_build.cpp
+++ b/src/build/raptor_build.cpp
@@ -19,10 +19,8 @@ void raptor_build(build_arguments const & arguments)
             hibf::chopper_build<seqan3::data_layout::compressed>(arguments);
         else
             hibf::chopper_build<seqan3::data_layout::uncompressed>(arguments);
-    else if (arguments.compressed)
-        build_ibf<true>(arguments);
     else
-        build_ibf<false>(arguments);
+        build_ibf(arguments);
 }
 
 } // namespace raptor


### PR DESCRIPTION
The same might be possible for the HIBF.
However, we create multiple IBFs for the HIBF. The IBFs are immediately stored in their compressed form inside the HIBF once they are constructed…