### PR TITLE
[MISC] Reuse compute_kmers in insert_to_ibf.

### DIFF
--- a/src/build/hibf/insert_into_ibf.cpp
+++ b/src/build/hibf/insert_into_ibf.cpp
@@ -13,8 +13,8 @@
 #include <seqan3/search/views/minimiser_hash.hpp>
 
 #include <raptor/adjust_seed.hpp>
-#include <raptor/build/hibf/insert_into_ibf.hpp>
 #include <raptor/build/hibf/compute_kmers.hpp>
+#include <raptor/build/hibf/insert_into_ibf.hpp>
 #include <raptor/file_reader.hpp>
 
 namespace raptor::hibf


### PR DESCRIPTION
Now this is something I need to benchmark.

The only difference is that a `robin_hood::unordered_set` is used instead of storing the values in a `std::vector<uint64_t>`.

IF this leads to a decrease in performance we need to have an compute_kmers overload on a vector.