### PR TITLE
[MISC] Store build_arguments in build_data.

### DIFF
--- a/include/raptor/build/hibf/build_data.hpp
+++ b/include/raptor/build/hibf/build_data.hpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 
+#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/node_data.hpp>
 #include <raptor/hierarchical_interleaved_bloom_filter.hpp>
 
@@ -24,6 +25,8 @@ namespace raptor::hibf
 
 struct build_data
 {
+    build_arguments const & arguments;
+
     std::atomic<size_t> ibf_number{};
 
     std::vector<std::vector<std::string>> filenames{};

--- a/include/raptor/build/hibf/compute_kmers.hpp
+++ b/include/raptor/build/hibf/compute_kmers.hpp
@@ -16,14 +16,12 @@
 
 #include <chopper/layout/layout.hpp>
 
-#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
 {
 
 void compute_kmers(robin_hood::unordered_flat_set<size_t> & kmers,
-                   build_arguments const & arguments,
                    build_data const & data,
                    chopper::layout::layout::user_bin const & record);
 

--- a/include/raptor/build/hibf/construct_ibf.hpp
+++ b/include/raptor/build/hibf/construct_ibf.hpp
@@ -14,7 +14,6 @@
 
 #include <robin_hood.h>
 
-#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
@@ -25,7 +24,6 @@ seqan3::interleaved_bloom_filter<> construct_ibf(robin_hood::unordered_flat_set<
                                                  size_t const number_of_bins,
                                                  lemon::ListDigraph::Node const & node,
                                                  build_data & data,
-                                                 build_arguments const & arguments,
                                                  bool is_root);
 
 } // namespace raptor::hibf

--- a/include/raptor/build/hibf/create_ibfs_from_chopper_pack.hpp
+++ b/include/raptor/build/hibf/create_ibfs_from_chopper_pack.hpp
@@ -12,12 +12,11 @@
 
 #pragma once
 
-#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
 {
 
-void create_ibfs_from_chopper_pack(build_data & data, build_arguments const & arguments);
+void create_ibfs_from_chopper_pack(build_data & data);
 
 } // namespace raptor::hibf

--- a/include/raptor/build/hibf/hierarchical_build.hpp
+++ b/include/raptor/build/hibf/hierarchical_build.hpp
@@ -14,7 +14,6 @@
 
 #include <robin_hood.h>
 
-#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
@@ -23,7 +22,6 @@ namespace raptor::hibf
 size_t hierarchical_build(robin_hood::unordered_flat_set<size_t> & parent_kmers,
                           lemon::ListDigraph::Node const & current_node,
                           build_data & data,
-                          build_arguments const & arguments,
                           bool is_root);
 
 } // namespace raptor::hibf

--- a/include/raptor/build/hibf/insert_into_ibf.hpp
+++ b/include/raptor/build/hibf/insert_into_ibf.hpp
@@ -18,7 +18,6 @@
 
 #include <chopper/layout/layout.hpp>
 
-#include <raptor/argument_parsing/build_arguments.hpp>
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
@@ -31,8 +30,7 @@ void insert_into_ibf(robin_hood::unordered_flat_set<size_t> const & kmers,
                      seqan3::interleaved_bloom_filter<> & ibf,
                      timer<concurrent::yes> & fill_ibf_timer);
 
-void insert_into_ibf(build_arguments const & arguments,
-                     build_data const & data,
+void insert_into_ibf(build_data const & data,
                      chopper::layout::layout::user_bin const & record,
                      seqan3::interleaved_bloom_filter<> & ibf);
 

--- a/include/raptor/build/hibf/loop_over_children.hpp
+++ b/include/raptor/build/hibf/loop_over_children.hpp
@@ -14,7 +14,6 @@
 
 #include <robin_hood.h>
 
-
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf

--- a/include/raptor/build/hibf/loop_over_children.hpp
+++ b/include/raptor/build/hibf/loop_over_children.hpp
@@ -14,7 +14,7 @@
 
 #include <robin_hood.h>
 
-#include <raptor/argument_parsing/build_arguments.hpp>
+
 #include <raptor/build/hibf/build_data.hpp>
 
 namespace raptor::hibf
@@ -25,7 +25,6 @@ void loop_over_children(robin_hood::unordered_flat_set<size_t> & parent_kmers,
                         std::vector<int64_t> & ibf_positions,
                         lemon::ListDigraph::Node const & current_node,
                         build_data & data,
-                        build_arguments const & arguments,
                         bool is_root);
 
 } // namespace raptor::hibf

--- a/src/build/hibf/chopper_build.cpp
+++ b/src/build/hibf/chopper_build.cpp
@@ -22,9 +22,9 @@ namespace raptor::hibf
 
 void chopper_build(build_arguments const & arguments)
 {
-    build_data data{};
+    build_data data{.arguments = arguments};
 
-    create_ibfs_from_chopper_pack(data, arguments);
+    create_ibfs_from_chopper_pack(data);
 
     arguments.index_allocation_timer.start();
     raptor_index<hierarchical_interleaved_bloom_filter> index{window{arguments.window_size},

--- a/src/build/hibf/compute_kmers.cpp
+++ b/src/build/hibf/compute_kmers.cpp
@@ -20,24 +20,23 @@ namespace raptor::hibf
 {
 
 void compute_kmers(robin_hood::unordered_flat_set<size_t> & kmers,
-                   build_arguments const & arguments,
                    build_data const & data,
                    chopper::layout::layout::user_bin const & record)
 {
     timer<concurrent::no> local_user_bin_io_timer{};
     local_user_bin_io_timer.start();
-    if (arguments.input_is_minimiser)
+    if (data.arguments.input_is_minimiser)
     {
         file_reader<file_types::minimiser> const reader{};
         reader.hash_into(data.filenames[record.idx], std::inserter(kmers, kmers.begin()));
     }
     else
     {
-        file_reader<file_types::sequence> const reader{arguments.shape, arguments.window_size};
+        file_reader<file_types::sequence> const reader{data.arguments.shape, data.arguments.window_size};
         reader.hash_into(data.filenames[record.idx], std::inserter(kmers, kmers.begin()));
     }
     local_user_bin_io_timer.stop();
-    arguments.user_bin_io_timer += local_user_bin_io_timer;
+    data.arguments.user_bin_io_timer += local_user_bin_io_timer;
 }
 
 } // namespace raptor::hibf

--- a/src/build/hibf/construct_ibf.cpp
+++ b/src/build/hibf/construct_ibf.cpp
@@ -25,25 +25,24 @@ seqan3::interleaved_bloom_filter<> construct_ibf(robin_hood::unordered_flat_set<
                                                  size_t const number_of_bins,
                                                  lemon::ListDigraph::Node const & node,
                                                  build_data & data,
-                                                 build_arguments const & arguments,
                                                  bool is_root)
 {
     auto & node_data = data.node_map[node];
 
     size_t const kmers_per_bin{static_cast<size_t>(std::ceil(static_cast<double>(kmers.size()) / number_of_bins))};
-    double const bin_bits{static_cast<double>(bin_size_in_bits(arguments, kmers_per_bin))};
+    double const bin_bits{static_cast<double>(bin_size_in_bits(data.arguments, kmers_per_bin))};
     seqan3::bin_size const bin_size{static_cast<size_t>(std::ceil(bin_bits * data.fp_correction[number_of_bins]))};
     seqan3::bin_count const bin_count{node_data.number_of_technical_bins};
 
     timer<concurrent::no> local_index_allocation_timer{};
     local_index_allocation_timer.start();
-    seqan3::interleaved_bloom_filter<> ibf{bin_count, bin_size, seqan3::hash_function_count{arguments.hash}};
+    seqan3::interleaved_bloom_filter<> ibf{bin_count, bin_size, seqan3::hash_function_count{data.arguments.hash}};
     local_index_allocation_timer.stop();
-    arguments.index_allocation_timer += local_index_allocation_timer;
+    data.arguments.index_allocation_timer += local_index_allocation_timer;
 
-    insert_into_ibf(kmers, number_of_bins, node_data.max_bin_index, ibf, arguments.fill_ibf_timer);
+    insert_into_ibf(kmers, number_of_bins, node_data.max_bin_index, ibf, data.arguments.fill_ibf_timer);
     if (!is_root)
-        update_parent_kmers(parent_kmers, kmers, arguments.merge_kmers_timer);
+        update_parent_kmers(parent_kmers, kmers, data.arguments.merge_kmers_timer);
 
     return ibf;
 }

--- a/src/build/hibf/create_ibfs_from_chopper_pack.cpp
+++ b/src/build/hibf/create_ibfs_from_chopper_pack.cpp
@@ -22,9 +22,9 @@
 namespace raptor::hibf
 {
 
-void create_ibfs_from_chopper_pack(build_data & data, build_arguments const & arguments)
+void create_ibfs_from_chopper_pack(build_data & data)
 {
-    chopper::layout::layout hibf_layout = read_chopper_pack_file(data.filenames, arguments.bin_file);
+    chopper::layout::layout hibf_layout = read_chopper_pack_file(data.filenames, data.arguments.bin_file);
 
     size_t const number_of_ibfs = hibf_layout.max_bins.size() + 1;
 
@@ -39,9 +39,9 @@ void create_ibfs_from_chopper_pack(build_data & data, build_arguments const & ar
     robin_hood::unordered_flat_set<size_t> root_kmers{};
 
     size_t const t_max{data.node_map[root].number_of_technical_bins};
-    data.fp_correction = chopper::layout::compute_fp_correction(arguments.fpr, arguments.hash, t_max);
+    data.fp_correction = chopper::layout::compute_fp_correction(data.arguments.fpr, data.arguments.hash, t_max);
 
-    hierarchical_build(root_kmers, root, data, arguments, true);
+    hierarchical_build(root_kmers, root, data, true);
 }
 
 } // namespace raptor::hibf

--- a/src/build/hibf/hierarchical_build.cpp
+++ b/src/build/hibf/hierarchical_build.cpp
@@ -47,8 +47,7 @@ size_t hierarchical_build(robin_hood::unordered_flat_set<size_t> & parent_kmers,
         if (node_data.favourite_child != lemon::INVALID) // max bin is a merged bin
         {
             // recursively initialize favourite child first
-            ibf_positions[node_data.max_bin_index] =
-                hierarchical_build(kmers, node_data.favourite_child, data, false);
+            ibf_positions[node_data.max_bin_index] = hierarchical_build(kmers, node_data.favourite_child, data, false);
             return 1;
         }
         else // max bin is not a merged bin
@@ -63,8 +62,7 @@ size_t hierarchical_build(robin_hood::unordered_flat_set<size_t> & parent_kmers,
     };
 
     // initialize lower level IBF
-    size_t const max_bin_tbs =
-        initialise_max_bin_kmers(kmers, ibf_positions, filename_indices, current_node, data);
+    size_t const max_bin_tbs = initialise_max_bin_kmers(kmers, ibf_positions, filename_indices, current_node, data);
     auto && ibf = construct_ibf(parent_kmers, kmers, max_bin_tbs, current_node, data, is_root);
     kmers.clear(); // reduce memory peak
 

--- a/src/build/hibf/insert_into_ibf.cpp
+++ b/src/build/hibf/insert_into_ibf.cpp
@@ -43,8 +43,7 @@ void insert_into_ibf(robin_hood::unordered_flat_set<size_t> const & kmers,
     fill_ibf_timer += local_fill_ibf_timer;
 }
 
-void insert_into_ibf(build_arguments const & arguments,
-                     build_data const & data,
+void insert_into_ibf(build_data const & data,
                      chopper::layout::layout::user_bin const & record,
                      seqan3::interleaved_bloom_filter<> & ibf)
 {
@@ -53,25 +52,25 @@ void insert_into_ibf(build_arguments const & arguments,
 
     timer<concurrent::no> local_user_bin_io_timer{};
     local_user_bin_io_timer.start();
-    if (arguments.input_is_minimiser)
+    if (data.arguments.input_is_minimiser)
     {
         file_reader<file_types::minimiser> const reader{};
         reader.hash_into(data.filenames[record.idx], std::back_inserter(values));
     }
     else
     {
-        file_reader<file_types::sequence> const reader{arguments.shape, arguments.window_size};
+        file_reader<file_types::sequence> const reader{data.arguments.shape, data.arguments.window_size};
         reader.hash_into(data.filenames[record.idx], std::back_inserter(values));
     }
     local_user_bin_io_timer.stop();
-    arguments.user_bin_io_timer += local_user_bin_io_timer;
+    data.arguments.user_bin_io_timer += local_user_bin_io_timer;
 
     timer<concurrent::no> local_fill_ibf_timer{};
     local_fill_ibf_timer.start();
     for (auto && value : values)
         ibf.emplace(value, bin_index);
     local_fill_ibf_timer.stop();
-    arguments.fill_ibf_timer += local_fill_ibf_timer;
+    data.arguments.fill_ibf_timer += local_fill_ibf_timer;
 }
 
 } // namespace raptor::hibf


### PR DESCRIPTION
This is helpful for making the whole building independent of `raptor build_arguments`, since the HIBF will get its own config that will replace the raptor build arguments. 