### PR TITLE
[FEATURE] Improved timing output

### DIFF
--- a/include/raptor/argument_parsing/build_arguments.hpp
+++ b/include/raptor/argument_parsing/build_arguments.hpp
@@ -17,9 +17,6 @@
 
 #include <seqan3/search/kmer_index/shape.hpp>
 
-#include <raptor/argument_parsing/memory_usage.hpp>
-#include <raptor/strong_types.hpp>
-
 #include <hibf/misc/timer.hpp>
 
 namespace raptor
@@ -34,7 +31,7 @@ struct build_arguments
     seqan3::shape shape{seqan3::ungapped{kmer_size}};
 
     // Related to IBF
-    std::filesystem::path out_path{"./"};
+    std::filesystem::path out_path{};
     uint64_t bins{64};
     mutable uint64_t bits{4096}; // Allow to change bits for each partition
     uint64_t hash{2};
@@ -48,6 +45,7 @@ struct build_arguments
     bool is_hibf{false};
     bool input_is_minimiser{false};
     bool quiet{false};
+    std::filesystem::path timing_out{};
 
     // Timers do not copy the stored duration upon copy construction/assignment
     mutable seqan::hibf::concurrent_timer wall_clock_timer{};
@@ -58,27 +56,8 @@ struct build_arguments
     mutable seqan::hibf::concurrent_timer fill_ibf_timer{};
     mutable seqan::hibf::concurrent_timer store_index_timer{};
 
-    void print_timings() const
-    {
-        if (quiet)
-            return;
-        std::cerr << std::fixed << std::setprecision(2) << "============= Timings =============\n";
-        std::cerr << "Wall clock time [s]: " << wall_clock_timer.in_seconds() << '\n';
-        std::cerr << "Peak memory usage " << formatted_peak_ram() << '\n';
-        if (!is_hibf)
-            std::cerr << "Determine IBF size [s]: " << bin_size_timer.in_seconds() << '\n';
-        std::cerr << "Index allocation [s]: " << index_allocation_timer.in_seconds() << '\n';
-        std::cerr << "User bin I/O avg per thread [s]: " << user_bin_io_timer.in_seconds() / threads << '\n';
-        std::cerr << "User bin I/O sum [s]: " << user_bin_io_timer.in_seconds() << '\n';
-        if (is_hibf)
-        {
-            std::cerr << "Merge kmer sets avg per thread [s]: " << merge_kmers_timer.in_seconds() / threads << '\n';
-            std::cerr << "Merge kmer sets sum [s]: " << merge_kmers_timer.in_seconds() << '\n';
-        }
-        std::cerr << "Fill IBF avg per thread [s]: " << fill_ibf_timer.in_seconds() / threads << '\n';
-        std::cerr << "Fill IBF sum [s]: " << fill_ibf_timer.in_seconds() << '\n';
-        std::cerr << "Store index [s]: " << store_index_timer.in_seconds() << '\n';
-    }
+    void print_timings() const;
+    void write_timings_to_file() const;
 };
 
 } // namespace raptor

--- a/include/raptor/argument_parsing/formatted_bytes.hpp
+++ b/include/raptor/argument_parsing/formatted_bytes.hpp
@@ -1,0 +1,94 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides raptor::formatted_bytes.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace raptor
+{
+
+[[nodiscard]] inline std::string formatted_bytes(size_t const bytes)
+{
+    assert(bytes > 0);
+
+    size_t iterations{};
+    size_t integer{bytes};
+
+    while (integer >> 10u && iterations < 6u)
+    {
+        integer >>= 10u;
+        ++iterations;
+    }
+
+    // While this is a bit more involved, we can avoid using floating point numbers.
+    auto first_decimal_position = [&]()
+    {
+        assert(iterations > 0u);
+        size_t decimal{bytes};
+        decimal -= integer << (iterations * 10u);             // Substract bytes represented by integer, e.g. -5GiB
+        decimal >>= (iterations - 1u) * 10u;                  // Shift to next smallest unit, e.g. 800MiB
+        decimal = decimal * 1000u / 1024u;                    // Account for using decimal system, i.e. 800MiB != 0.8GiB
+        size_t const diff{decimal - (decimal / 100u) * 100u}; // We want to round up to 1 decimal position
+        uint32_t const round_up{diff >= 50u};
+        decimal += round_up * 100u - diff;
+        decimal /= 100u;
+        return decimal;
+    };
+
+    auto formatted_string = [&]()
+    {
+        static constexpr int8_t int_to_char_offset{'0'}; // int 0 as char: char{0 + 48} = '0'
+        size_t const decimal = iterations ? first_decimal_position() : 0u;
+        assert(decimal <= 10u);
+
+        if (!iterations) // No decimals for Bytes
+            return std::to_string(integer);
+        else if (decimal < 10u) // No need to round integer part
+            return std::to_string(integer) + '.' + static_cast<char>(decimal + int_to_char_offset);
+        else // Round integer part, e.g., 5.99 MiB should report 6.0 MiB
+        {
+            ++integer;
+            // Check whether rounding results in a change of unit, e.g. 1023.99MiB to 1.0GiB
+            if (integer >> 10u)
+            {
+                ++iterations;
+                integer >>= 10u;
+            }
+            return std::to_string(integer) + ".0";
+        }
+    };
+
+    std::string const formatted{formatted_string()};
+    switch (iterations)
+    {
+    case 0:
+        return "[Bytes]: " + formatted;
+    case 1:
+        return "[KiB]: " + formatted;
+    case 2:
+        return "[MiB]: " + formatted;
+    case 3:
+        return "[GiB]: " + formatted;
+    case 4:
+        return "[TiB]: " + formatted;
+    case 5:
+        return "[PiB]: " + formatted;
+    default:
+        return "[EiB]: " + formatted;
+    }
+}
+
+} // namespace raptor

--- a/include/raptor/argument_parsing/formatted_index_size.hpp
+++ b/include/raptor/argument_parsing/formatted_index_size.hpp
@@ -1,0 +1,48 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides raptor::formatted_index_size.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <filesystem>
+#include <string>
+
+#include <raptor/argument_parsing/formatted_bytes.hpp>
+
+namespace raptor
+{
+
+[[nodiscard]] inline size_t index_size_in_KiB(std::filesystem::path index_path, uint8_t const parts)
+{
+    size_t index_size_in_bytes{};
+    if (parts == 1u)
+    {
+        index_size_in_bytes = std::filesystem::file_size(index_path);
+    }
+    else
+    {
+        for (size_t part = 0u; part < parts; ++part)
+        {
+            index_size_in_bytes += std::filesystem::file_size(index_path.string() + "_" + std::to_string(part));
+        }
+    }
+
+    return index_size_in_bytes >> 10;
+}
+
+[[nodiscard]] inline std::string formatted_index_size(std::filesystem::path index_path, uint8_t const parts)
+{
+    return formatted_bytes(index_size_in_KiB(index_path, parts) << 10);
+}
+
+} // namespace raptor

--- a/include/raptor/argument_parsing/memory_usage.hpp
+++ b/include/raptor/argument_parsing/memory_usage.hpp
@@ -16,6 +16,8 @@
 #include <cstdint>
 #include <string>
 
+#include <raptor/argument_parsing/formatted_bytes.hpp>
+
 #if __has_include(<sys/resource.h>)
 #    include <sys/resource.h>
 #endif
@@ -23,15 +25,16 @@
 namespace raptor
 {
 
-namespace detail
-{
-
 #if __has_include(<sys/resource.h>)
 // Returns -1 if not available. Actually returns bytes instead of KiB on macOS.
 inline long peak_ram_in_KiB()
 {
     rusage usage;
+#    if __APPLE__
+    return getrusage(RUSAGE_SELF, &usage) == 0 ? (usage.ru_maxrss >> 10) : -1L;
+#    else
     return getrusage(RUSAGE_SELF, &usage) == 0 ? usage.ru_maxrss : -1L;
+#    endif
 }
 #else
 inline long peak_ram_in_KiB()
@@ -40,89 +43,13 @@ inline long peak_ram_in_KiB()
 }
 #endif
 
-[[nodiscard]] inline std::string formatted_peak_ram(size_t const bytes)
-{
-    assert(bytes > 0);
-
-    size_t iterations{};
-    size_t integer{bytes};
-
-    while (integer >> 10u && iterations < 6u)
-    {
-        integer >>= 10u;
-        ++iterations;
-    }
-
-    // While this is a bit more involved, we can avoid using floating point numbers.
-    auto first_decimal_position = [&]()
-    {
-        assert(iterations > 0u);
-        size_t decimal{bytes};
-        decimal -= integer << (iterations * 10u);             // Substract bytes represented by integer, e.g. -5GiB
-        decimal >>= (iterations - 1u) * 10u;                  // Shift to next smallest unit, e.g. 800MiB
-        decimal = decimal * 1000u / 1024u;                    // Account for using decimal system, i.e. 800MiB != 0.8GiB
-        size_t const diff{decimal - (decimal / 100u) * 100u}; // We want to round up to 1 decimal position
-        uint32_t const round_up{diff >= 50u};
-        decimal += round_up * 100u - diff;
-        decimal /= 100u;
-        return decimal;
-    };
-
-    auto formatted_string = [&]()
-    {
-        static constexpr int8_t int_to_char_offset{'0'}; // int 0 as char: char{0 + 48} = '0'
-        size_t const decimal = iterations ? first_decimal_position() : 0u;
-        assert(decimal <= 10u);
-
-        if (!iterations) // No decimals for Bytes
-            return std::to_string(integer);
-        else if (decimal < 10u) // No need to round integer part
-            return std::to_string(integer) + '.' + static_cast<char>(decimal + int_to_char_offset);
-        else // Round integer part, e.g., 5.99 MiB should report 6.0 MiB
-        {
-            ++integer;
-            // Check whether rounding results in a change of unit, e.g. 1023.99MiB to 1.0GiB
-            if (integer >> 10u)
-            {
-                ++iterations;
-                integer >>= 10u;
-            }
-            return std::to_string(integer) + ".0";
-        }
-    };
-
-    std::string const formatted{formatted_string()};
-    switch (iterations)
-    {
-    case 0:
-        return "[Bytes]: " + formatted;
-    case 1:
-        return "[KiB]: " + formatted;
-    case 2:
-        return "[MiB]: " + formatted;
-    case 3:
-        return "[GiB]: " + formatted;
-    case 4:
-        return "[TiB]: " + formatted;
-    case 5:
-        return "[PiB]: " + formatted;
-    default:
-        return "[EiB]: " + formatted;
-    }
-}
-
-} // namespace detail
-
 [[nodiscard]] inline std::string formatted_peak_ram()
 {
-    long const peak_ram_KiB = detail::peak_ram_in_KiB();
+    long const peak_ram_KiB = peak_ram_in_KiB();
     if (peak_ram_KiB == -1L)
         return {": Not available"}; // GCOVR_EXCL_LINE
-#if __APPLE__
-    return detail::formatted_peak_ram(static_cast<size_t>(peak_ram_KiB));
-#else
-    return detail::formatted_peak_ram(static_cast<size_t>(peak_ram_KiB) << 10);
-#endif
+
+    return formatted_bytes(static_cast<size_t>(peak_ram_KiB) << 10);
 }
 
 } // namespace raptor

--- a/include/raptor/argument_parsing/search_arguments.hpp
+++ b/include/raptor/argument_parsing/search_arguments.hpp
@@ -17,6 +17,7 @@
 
 #include <seqan3/search/kmer_index/shape.hpp>
 
+#include <raptor/argument_parsing/formatted_index_size.hpp>
 #include <raptor/argument_parsing/memory_usage.hpp>
 #include <raptor/threshold/threshold_parameters.hpp>
 
@@ -54,6 +55,7 @@ struct search_arguments
     bool is_hibf{false};
     bool cache_thresholds{false};
     bool quiet{false};
+    std::filesystem::path timing_out{};
 
     // Timers do not copy the stored duration upon copy construction/assignment
     mutable seqan::hibf::concurrent_timer wall_clock_timer{};
@@ -64,20 +66,8 @@ struct search_arguments
     mutable seqan::hibf::concurrent_timer query_ibf_timer{};
     mutable seqan::hibf::concurrent_timer generate_results_timer{};
 
-    void print_timings() const
-    {
-        if (quiet)
-            return;
-        std::cerr << std::fixed << std::setprecision(2) << "============= Timings =============\n";
-        std::cerr << "Wall clock time [s]: " << wall_clock_timer.in_seconds() << '\n';
-        std::cerr << "Peak memory usage " << formatted_peak_ram() << '\n';
-        std::cerr << "Determine query length [s]: " << query_length_timer.in_seconds() << '\n';
-        std::cerr << "Query file I/O [s]: " << query_file_io_timer.in_seconds() << '\n';
-        std::cerr << "Load index [s]: " << load_index_timer.in_seconds() << '\n';
-        std::cerr << "Compute minimiser [s]: " << compute_minimiser_timer.in_seconds() / threads << '\n';
-        std::cerr << "Query IBF [s]: " << query_ibf_timer.in_seconds() / threads << '\n';
-        std::cerr << "Generate results [s]: " << generate_results_timer.in_seconds() / threads << '\n';
-    }
+    void print_timings() const;
+    void write_timings_to_file() const;
 
     raptor::threshold::threshold_parameters make_threshold_parameters() const noexcept
     {

--- a/src/argument_parsing/CMakeLists.txt
+++ b/src/argument_parsing/CMakeLists.txt
@@ -39,11 +39,13 @@ if (NOT TARGET raptor_argument_parsing)
     endif ()
 
     add_library ("raptor_argument_parsing" STATIC
+                 build_arguments.cpp
                  build_parsing.cpp
                  compute_bin_size.cpp
                  init_shared_meta.cpp
                  parse_bin_path.cpp
                  prepare_parsing.cpp
+                 search_arguments.cpp
                  search_parsing.cpp
                  upgrade_parsing.cpp
     )

--- a/src/argument_parsing/build_arguments.cpp
+++ b/src/argument_parsing/build_arguments.cpp
@@ -1,0 +1,105 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Implements raptor::build_arguments.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#include <fstream>
+
+#include <raptor/argument_parsing/build_arguments.hpp>
+#include <raptor/argument_parsing/formatted_index_size.hpp>
+#include <raptor/argument_parsing/memory_usage.hpp>
+
+namespace raptor
+{
+
+void build_arguments::print_timings() const
+{
+    std::cerr << std::fixed << std::setprecision(2) << "============= Timings =============\n";
+    std::cerr << "Wall clock time [s]: " << wall_clock_timer.in_seconds() << '\n';
+    std::cerr << "Peak memory usage " << formatted_peak_ram() << '\n';
+    std::cerr << "Index size " << formatted_index_size(out_path, parts) << '\n';
+
+    if (is_hibf)
+        std::cerr << "Determine IBF size [s]: NA\n";
+    else
+        std::cerr << "Determine IBF size [s]: " << bin_size_timer.in_seconds() << '\n';
+
+    std::cerr << "Index allocation [s]: " << index_allocation_timer.in_seconds() << '\n';
+    std::cerr << "User bin I/O avg per thread [s]: " << user_bin_io_timer.in_seconds() / threads << '\n';
+    std::cerr << "User bin I/O sum [s]: " << user_bin_io_timer.in_seconds() << '\n';
+
+    if (is_hibf)
+    {
+        std::cerr << "Merge kmer sets avg per thread [s]: " << merge_kmers_timer.in_seconds() / threads << '\n';
+        std::cerr << "Merge kmer sets sum [s]: " << merge_kmers_timer.in_seconds() << '\n';
+    }
+    else
+    {
+        std::cerr << "Merge kmer sets avg per thread [s]: NA\n";
+        std::cerr << "Merge kmer sets sum [s]: NA\n";
+    }
+
+    std::cerr << "Fill IBF avg per thread [s]: " << fill_ibf_timer.in_seconds() / threads << '\n';
+    std::cerr << "Fill IBF sum [s]: " << fill_ibf_timer.in_seconds() << '\n';
+    std::cerr << "Store index [s]: " << store_index_timer.in_seconds() << '\n';
+}
+
+void build_arguments::write_timings_to_file() const
+{
+    std::ofstream output_stream{timing_out};
+    output_stream << std::fixed << std::setprecision(2);
+    output_stream << "wall_clock_time_in_seconds\t"
+                  << "peak_memory_usage_in_KiB\t"
+                  << "index_size_in_KiB\t"
+                  << "determine_ibf_size_in_seconds\t"
+                  << "index_allocation_in_seconds\t"
+                  << "user_bin_io_avg_per_thread_in_seconds\t"
+                  << "user_bin_io_sum_in_seconds\t"
+                  << "merge_kmer_sets_avg_per_thread_in_seconds\t"
+                  << "merge_kmer_sets_sum_in_seconds\t"
+                  << "fill_ibf_avg_per_thread_in_seconds\t"
+                  << "fill_ibf_sum_in_seconds\t"
+                  << "store_index_in_seconds\n";
+
+    output_stream << wall_clock_timer.in_seconds() << '\t';
+
+    if (long const peak_ram_KiB = peak_ram_in_KiB(); peak_ram_KiB != -1L)
+        output_stream << peak_ram_KiB << '\t';
+    else
+        output_stream << "NA\t"; // GCOVR_EXCL_LINE
+
+    output_stream << index_size_in_KiB(out_path, parts) << '\t';
+
+    if (is_hibf)
+        output_stream << "NA\t";
+    else
+        output_stream << bin_size_timer.in_seconds() << '\t';
+
+    output_stream << index_allocation_timer.in_seconds() << '\t';
+    output_stream << user_bin_io_timer.in_seconds() / threads << '\t';
+    output_stream << user_bin_io_timer.in_seconds() << '\t';
+
+    if (is_hibf)
+    {
+        output_stream << merge_kmers_timer.in_seconds() / threads << '\t';
+        output_stream << merge_kmers_timer.in_seconds() << '\t';
+    }
+    else
+    {
+        output_stream << "NA\t";
+        output_stream << "NA\t";
+    }
+
+    output_stream << fill_ibf_timer.in_seconds() / threads << '\t';
+    output_stream << fill_ibf_timer.in_seconds() << '\t';
+    output_stream << store_index_timer.in_seconds() << '\n';
+}
+
+} // namespace raptor

--- a/src/argument_parsing/build_parsing.cpp
+++ b/src/argument_parsing/build_parsing.cpp
@@ -129,9 +129,15 @@ void init_build_parser(sharg::parser & parser, build_arguments & arguments)
                                     .long_id = "threads",
                                     .description = "The number of threads to use.",
                                     .validator = positive_integer_validator{}});
-    parser.add_flag(
-        arguments.quiet,
-        sharg::config{.short_id = '\0', .long_id = "quiet", .description = "Do not print time and memory usage."});
+    parser.add_flag(arguments.quiet,
+                    sharg::config{.short_id = '\0',
+                                  .long_id = "quiet",
+                                  .description = "Do not print time and memory usage to stderr."});
+    parser.add_option(arguments.timing_out,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "timing-output",
+                                    .description = "Write time and memory usage to specified file (TSV format).",
+                                    .validator = output_file_validator{}});
 
     parser.add_subsection("k-mer options");
     parser.add_option(
@@ -266,7 +272,10 @@ void build_parsing(sharg::parser & parser)
     raptor_build(arguments);
 
     arguments.wall_clock_timer.stop();
-    arguments.print_timings();
+    if (!arguments.quiet)
+        arguments.print_timings();
+    if (parser.is_option_set("timing-output"))
+        arguments.write_timings_to_file();
 }
 
 } // namespace raptor

--- a/src/argument_parsing/search_arguments.cpp
+++ b/src/argument_parsing/search_arguments.cpp
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Implements raptor::search_arguments.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#include <fstream>
+
+#include <raptor/argument_parsing/formatted_index_size.hpp>
+#include <raptor/argument_parsing/memory_usage.hpp>
+#include <raptor/argument_parsing/search_arguments.hpp>
+
+namespace raptor
+{
+
+void search_arguments::print_timings() const
+{
+    std::cerr << std::fixed << std::setprecision(2) << "============= Timings =============\n";
+    std::cerr << "Wall clock time [s]: " << wall_clock_timer.in_seconds() << '\n';
+    std::cerr << "Peak memory usage " << formatted_peak_ram() << '\n';
+    std::cerr << "Index size " << formatted_index_size(index_file, parts) << '\n';
+    std::cerr << "Determine query length [s]: " << query_length_timer.in_seconds() << '\n';
+    std::cerr << "Query file I/O [s]: " << query_file_io_timer.in_seconds() << '\n';
+    std::cerr << "Load index [s]: " << load_index_timer.in_seconds() << '\n';
+    std::cerr << "Compute minimiser avg per thread [s]: " << compute_minimiser_timer.in_seconds() / threads << '\n';
+    std::cerr << "Compute minimiser sum [s]: " << compute_minimiser_timer.in_seconds() << '\n';
+    std::cerr << "Query IBF avg per thread [s]: " << query_ibf_timer.in_seconds() / threads << '\n';
+    std::cerr << "Query IBF sum [s]: " << query_ibf_timer.in_seconds() << '\n';
+    std::cerr << "Generate results avg per thread [s]: " << generate_results_timer.in_seconds() / threads << '\n';
+    std::cerr << "Generate results sum [s]: " << generate_results_timer.in_seconds() << '\n';
+}
+
+void search_arguments::write_timings_to_file() const
+{
+    std::ofstream output_stream{timing_out};
+    output_stream << std::fixed << std::setprecision(2);
+    output_stream << "wall_clock_time_in_seconds\t"
+                  << "peak_memory_usage_in_KiB\t"
+                  << "index_size_in_KiB\t"
+                  << "determine_query_length_in_seconds\t"
+                  << "query_file_io_in_seconds\t"
+                  << "load_index_in_seconds\t"
+                  << "compute_minimiser_avg_per_thread_in_seconds\t"
+                  << "compute_minimiser_sum_in_seconds\t"
+                  << "query_ibf_avg_per_thread_in_seconds\t"
+                  << "query_ibf_sum_in_seconds\t"
+                  << "generate_results_avg_per_thread_in_seconds\t"
+                  << "generate_results_sum_in_seconds\n";
+
+    output_stream << wall_clock_timer.in_seconds() << '\t';
+
+    if (long const peak_ram_KiB = peak_ram_in_KiB(); peak_ram_KiB != -1L)
+        output_stream << peak_ram_KiB << '\t';
+    else
+        output_stream << "NA\t"; // GCOVR_EXCL_LINE
+
+    output_stream << index_size_in_KiB(index_file, parts) << '\t';
+    output_stream << query_length_timer.in_seconds() << '\t';
+    output_stream << query_file_io_timer.in_seconds() << '\t';
+    output_stream << load_index_timer.in_seconds() << '\t';
+    output_stream << compute_minimiser_timer.in_seconds() / threads << '\t';
+    output_stream << compute_minimiser_timer.in_seconds() << '\t';
+    output_stream << query_ibf_timer.in_seconds() / threads << '\t';
+    output_stream << query_ibf_timer.in_seconds() << '\t';
+    output_stream << generate_results_timer.in_seconds() / threads << '\t';
+    output_stream << generate_results_timer.in_seconds() << '\n';
+}
+
+} // namespace raptor

--- a/src/argument_parsing/search_parsing.cpp
+++ b/src/argument_parsing/search_parsing.cpp
@@ -60,9 +60,15 @@ void init_search_parser(sharg::parser & parser, search_arguments & arguments)
                                     .long_id = "threads",
                                     .description = "The number of threads to use.",
                                     .validator = positive_integer_validator{}});
-    parser.add_flag(
-        arguments.quiet,
-        sharg::config{.short_id = '\0', .long_id = "quiet", .description = "Do not print time and memory usage."});
+    parser.add_flag(arguments.quiet,
+                    sharg::config{.short_id = '\0',
+                                  .long_id = "quiet",
+                                  .description = "Do not print time and memory usage to stderr."});
+    parser.add_option(arguments.timing_out,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "timing-output",
+                                    .description = "Write time and memory usage to specified file (TSV format).",
+                                    .validator = output_file_validator{}});
 
     parser.add_subsection("Threshold method options");
     parser.add_line("\\fBIf no option is set, --error " + std::to_string(arguments.errors)
@@ -245,7 +251,10 @@ void search_parsing(sharg::parser & parser)
     raptor_search(arguments);
 
     arguments.wall_clock_timer.stop();
-    arguments.print_timings();
+    if (!arguments.quiet)
+        arguments.print_timings();
+    if (parser.is_option_set("timing-output"))
+        arguments.write_timings_to_file();
 }
 
 } // namespace raptor

--- a/test/unit/api/CMakeLists.txt
+++ b/test/unit/api/CMakeLists.txt
@@ -8,5 +8,7 @@
 cmake_minimum_required (VERSION 3.10)
 
 raptor_add_unit_test (issue_142.cpp)
+raptor_add_unit_test (formatted_bytes.cpp)
+raptor_add_unit_test (index_size.cpp)
 raptor_add_unit_test (memory_usage.cpp)
 raptor_add_unit_test (validate_shape.cpp)

--- a/test/unit/api/formatted_bytes.cpp
+++ b/test/unit/api/formatted_bytes.cpp
@@ -1,0 +1,79 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <raptor/argument_parsing/formatted_bytes.hpp>
+
+[[nodiscard]] consteval size_t exact(int const shift)
+{
+    if (shift >= 64)
+        throw std::invalid_argument("Shift value is too big. This is UB!");
+    return size_t{1u} << shift;
+}
+
+[[nodiscard]] consteval size_t with_decimal(int const shift)
+{
+    if (shift < 1)
+        throw std::invalid_argument("Shift value must be greater than 1.");
+    if (shift >= 64)
+        throw std::invalid_argument("Shift value is too big. This is UB!");
+    return (size_t{1u} << shift) + (size_t{1u} << (shift - 1));
+}
+
+[[nodiscard]] consteval size_t rounded(int const shift)
+{
+    if (shift >= 54)
+        throw std::invalid_argument("Shift value is too big. This is UB!");
+    return (size_t{1u} << (shift + 10)) - 10;
+}
+
+TEST(formatted, bytes)
+{
+    EXPECT_EQ(raptor::formatted_bytes(128), "[Bytes]: 128");
+}
+
+TEST(formatted, KiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(10)), "[KiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(10)), "[KiB]: 1.5");
+    EXPECT_EQ(raptor::formatted_bytes(rounded(10)), "[MiB]: 1.0");
+}
+
+TEST(formatted, MiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(20)), "[MiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(20)), "[MiB]: 1.5");
+    EXPECT_EQ(raptor::formatted_bytes(rounded(20)), "[GiB]: 1.0");
+}
+
+TEST(formatted, GiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(30)), "[GiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(30)), "[GiB]: 1.5");
+    EXPECT_EQ(raptor::formatted_bytes(rounded(30)), "[TiB]: 1.0");
+}
+
+TEST(formatted, TiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(40)), "[TiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(40)), "[TiB]: 1.5");
+    EXPECT_EQ(raptor::formatted_bytes(rounded(40)), "[PiB]: 1.0");
+}
+
+TEST(formatted, PiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(50)), "[PiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(50)), "[PiB]: 1.5");
+    EXPECT_EQ(raptor::formatted_bytes(rounded(50)), "[EiB]: 1.0");
+}
+
+TEST(formatted, EiB)
+{
+    EXPECT_EQ(raptor::formatted_bytes(exact(60)), "[EiB]: 1.0");
+    EXPECT_EQ(raptor::formatted_bytes(with_decimal(60)), "[EiB]: 1.5");
+}

--- a/test/unit/api/index_size.cpp
+++ b/test/unit/api/index_size.cpp
@@ -1,0 +1,45 @@
+// --------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/raptor/blob/main/LICENSE.md
+// --------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <raptor/argument_parsing/formatted_index_size.hpp>
+
+struct helper
+{
+    static std::filesystem::path data(std::string const & filename)
+    {
+        return std::filesystem::path{std::string{DATADIR}}.concat(filename);
+    }
+};
+
+TEST(index_size, ibf)
+{
+    size_t const size_in_KiB = raptor::index_size_in_KiB(helper::data("1bins23window.index"), 1u);
+    EXPECT_EQ(size_in_KiB, 7u);
+
+    std::string const formatted_size = raptor::formatted_index_size(helper::data("1bins23window.index"), 1u);
+    EXPECT_EQ(formatted_size, "[KiB]: 7.0");
+}
+
+TEST(index_size, ibf_partitioned)
+{
+    size_t const size_in_KiB = raptor::index_size_in_KiB(helper::data("2.0.partitioned.index"), 4u);
+    EXPECT_EQ(size_in_KiB, 34u);
+
+    std::string const formatted_size = raptor::formatted_index_size(helper::data("2.0.partitioned.index"), 4u);
+    EXPECT_EQ(formatted_size, "[KiB]: 34.0");
+}
+
+TEST(index_size, hibf)
+{
+    size_t const size_in_KiB = raptor::index_size_in_KiB(helper::data("128bins23window.hibf"), 1u);
+    EXPECT_EQ(size_in_KiB, 218u);
+
+    std::string const formatted_size = raptor::formatted_index_size(helper::data("128bins23window.hibf"), 1u);
+    EXPECT_EQ(formatted_size, "[KiB]: 218.0");
+}

--- a/test/unit/api/memory_usage.cpp
+++ b/test/unit/api/memory_usage.cpp
@@ -9,77 +9,15 @@
 
 #include <raptor/argument_parsing/memory_usage.hpp>
 
-consteval size_t exact(int const shift)
-{
-    if (shift >= 64)
-        throw std::invalid_argument("Shift value is too big. This is UB!");
-    return size_t{1u} << shift;
-}
-
-consteval size_t with_decimal(int const shift)
-{
-    if (shift < 1)
-        throw std::invalid_argument("Shift value must be greater than 1.");
-    if (shift >= 64)
-        throw std::invalid_argument("Shift value is too big. This is UB!");
-    return (size_t{1u} << shift) + (size_t{1u} << (shift - 1));
-}
-
-consteval size_t rounded(int const shift)
-{
-    if (shift >= 54)
-        throw std::invalid_argument("Shift value is too big. This is UB!");
-    return (size_t{1u} << (shift + 10)) - 10;
-}
-
-TEST(peak_ram, bytes)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(128), "[Bytes]: 128");
-}
-
-TEST(peak_ram, KiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(10)), "[KiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(10)), "[KiB]: 1.5");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(rounded(10)), "[MiB]: 1.0");
-}
-
-TEST(peak_ram, MiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(20)), "[MiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(20)), "[MiB]: 1.5");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(rounded(20)), "[GiB]: 1.0");
-}
-
-TEST(peak_ram, GiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(30)), "[GiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(30)), "[GiB]: 1.5");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(rounded(30)), "[TiB]: 1.0");
-}
-
-TEST(peak_ram, TiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(40)), "[TiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(40)), "[TiB]: 1.5");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(rounded(40)), "[PiB]: 1.0");
-}
-
-TEST(peak_ram, PiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(50)), "[PiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(50)), "[PiB]: 1.5");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(rounded(50)), "[EiB]: 1.0");
-}
-
-TEST(peak_ram, EiB)
-{
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(exact(60)), "[EiB]: 1.0");
-    EXPECT_EQ(raptor::detail::formatted_peak_ram(with_decimal(60)), "[EiB]: 1.5");
-}
-
 #if __has_include(<sys/resource.h>)
-TEST(peak_ram, via_OS)
+TEST(peak_ram, as_KiB)
+{
+    long const result = raptor::peak_ram_in_KiB();
+    EXPECT_GT(result, 1024L);
+    EXPECT_LT(result, 102400L);
+}
+
+TEST(peak_ram, as_string)
 {
     std::string const result = raptor::formatted_peak_ram();
     EXPECT_TRUE(result.starts_with("[KiB]: ") || result.starts_with("[MiB]: ")) << result;

--- a/test/unit/cli/build/build_hibf_test.cpp
+++ b/test/unit/cli/build/build_hibf_test.cpp
@@ -97,10 +97,12 @@ TEST_F(build_hibf, verbose)
                                                "--window 19",
                                                "--threads 1",
                                                "--output raptor.index",
+                                               "--timing-output raptor.time",
                                                "--input",
                                                data("three_levels.pack"));
     EXPECT_EQ(result.out, std::string{});
-    EXPECT_NE(result.err, std::string{});
+    EXPECT_TRUE(result.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("raptor.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result);
 
     compare_index<raptor::index_structure::hibf>(data("three_levels.hibf"), "raptor.index");

--- a/test/unit/cli/build/build_ibf_partitioned_test.cpp
+++ b/test/unit/cli/build/build_ibf_partitioned_test.cpp
@@ -38,11 +38,12 @@ TEST_P(build_ibf_partitioned, pipeline)
                                                 "--threads 2",
                                                 "--parts ",
                                                 std::to_string(parts),
-                                                "--quiet",
+                                                "--timing-output raptor.time",
                                                 "--input",
                                                 "raptor_cli_test.txt");
     EXPECT_EQ(result1.out, std::string{});
-    EXPECT_EQ(result1.err, std::string{});
+    EXPECT_TRUE(result1.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("raptor.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result1);
 
     cli_test_result const result2 = execute_app("raptor",
@@ -52,11 +53,12 @@ TEST_P(build_ibf_partitioned, pipeline)
                                                 std::to_string(number_of_errors),
                                                 "--index ",
                                                 "raptor.index",
-                                                "--quiet",
+                                                "--timing-output search.time",
                                                 "--query ",
                                                 data("query.fq"));
     EXPECT_EQ(result2.out, std::string{});
-    EXPECT_EQ(result2.err, std::string{});
+    EXPECT_TRUE(result2.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("search.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result2);
 
     compare_search(number_of_repeated_bins, number_of_errors, "search.out");

--- a/test/unit/cli/build/build_ibf_test.cpp
+++ b/test/unit/cli/build/build_ibf_test.cpp
@@ -98,10 +98,12 @@ TEST_F(build_ibf, verbose)
                                                "--window 19",
                                                "--threads 1",
                                                "--output raptor.index",
+                                               "--timing-output raptor.time",
                                                "--input",
                                                "raptor_cli_test.txt");
     EXPECT_EQ(result.out, std::string{});
-    EXPECT_NE(result.err, std::string{});
+    EXPECT_TRUE(result.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("raptor.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result);
 
     compare_index(ibf_path(16, 19), "raptor.index");

--- a/test/unit/cli/search/search_hibf_test.cpp
+++ b/test/unit/cli/search/search_hibf_test.cpp
@@ -93,11 +93,12 @@ TEST_F(search_hibf, three_levels)
                                                "--error 0",
                                                "--index ",
                                                data("three_levels.hibf"),
-                                               "--quiet",
+                                               "--timing-output raptor.time",
                                                "--query ",
                                                data("query.fq"));
     EXPECT_EQ(result.out, std::string{});
-    EXPECT_EQ(result.err, std::string{});
+    EXPECT_TRUE(result.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("raptor.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result);
 
     compare_search(32, 0, "search.out");

--- a/test/unit/cli/search/search_ibf_test.cpp
+++ b/test/unit/cli/search/search_ibf_test.cpp
@@ -132,6 +132,7 @@ TEST_F(search_ibf, verbose)
     cli_test_result const result = execute_app("raptor",
                                                "search",
                                                "--output search.out",
+                                               "--timing-output raptor.time",
                                                "--error 1",
                                                "--p_max 0.4",
                                                "--index ",
@@ -139,7 +140,8 @@ TEST_F(search_ibf, verbose)
                                                "--query ",
                                                data("query.fq"));
     EXPECT_EQ(result.out, std::string{});
-    EXPECT_NE(result.err, std::string{});
+    EXPECT_TRUE(result.err.starts_with("============= Timings ============="));
+    EXPECT_TRUE(std::filesystem::exists("raptor.time"));
     RAPTOR_ASSERT_ZERO_EXIT(result);
 
     compare_search(16, 1, "search.out");


### PR DESCRIPTION
Resolves #391 

Index size and RAM are always `KiB` in the timing-output

Todo:
* [ ] Tests


`column -ts $'\t' times.tsv`