### PR TITLE
[UPDATE] Missing update on generate reads refseq

### DIFF
--- a/util/applications/src/iScience/CMakeLists.txt
+++ b/util/applications/src/iScience/CMakeLists.txt
@@ -38,7 +38,18 @@ if (NOT TARGET apply_taxsbp)
 endif ()
 
 if (NOT TARGET generate_reads_refseq)
-    add_executable ("generate_reads_refseq" generate_reads_refseq.cpp)
+    add_executable ("generate_reads_refseq"
+                    generate_reads/apply_weights.cpp
+                    generate_reads/infer_weights_from_file_size.cpp
+                    generate_reads/infer_weights_from_hll_sketches.cpp
+                    generate_reads/infer_weights_from_kmer_counts.cpp
+                    generate_reads/infer_weights_from_uniform_distribution.cpp
+                    generate_reads/initialise_argument_parser.cpp
+                    generate_reads/parse_input.cpp
+                    generate_reads/print_weights.cpp
+                    generate_reads/simulate_reads.cpp
+                    generate_reads_refseq.cpp
+    )
     target_link_libraries ("generate_reads_refseq" "utility_common")
 endif ()
 

--- a/util/applications/src/iScience/generate_reads/apply_weights.cpp
+++ b/util/applications/src/iScience/generate_reads/apply_weights.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+namespace raptor::util::generate_reads
+{
+
+// Input
+// vec = arguments.number_of_reads_per_bin
+// vec was initialised with the weights of the bins
+// Output
+// vec is modified in place to contain the weights normalized to the number of reads
+void apply_weights(std::vector<size_t> & vec, size_t const number_of_reads)
+{
+    // std::reduce is the same as std::accumulate, except out of order execution is allowed
+    // std::reduce also infers the type that should be used for the initial value (here size_t)
+    auto const sum_of_weights = std::reduce(vec.begin(), vec.end());
+    static_assert(std::same_as<decltype(sum_of_weights), size_t const>); // Distrust
+
+    double const scaling_factor = static_cast<double>(number_of_reads) / sum_of_weights;
+
+    for (size_t & weight : vec)
+        weight = std::round(weight * scaling_factor);
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/cmd_arguments.hpp
+++ b/util/applications/src/iScience/generate_reads/cmd_arguments.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+namespace raptor::util::generate_reads
+{
+
+enum class weight : uint8_t
+{
+    from_file_sizes,
+    from_hll_sketches,
+    from_kmer_counts,
+    from_weight_column,
+    from_uniform_distribution
+};
+
+struct cmd_arguments
+{
+    // User input
+    weight weight_mode{weight::from_hll_sketches};
+    std::filesystem::path bin_file_path{};
+    std::filesystem::path output_filename{};
+    uint8_t errors{2u};
+    uint32_t read_length{100u};
+    uint64_t number_of_reads{1ULL << 20};
+    uint64_t threads{1u};
+    bool print_weights{false};
+
+    // Internal state
+    size_t number_of_bins{};
+    std::vector<std::filesystem::path> bin_path{};
+    std::vector<size_t> number_of_reads_per_bin{};
+};
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/infer_weights_from_file_size.cpp
+++ b/util/applications/src/iScience/generate_reads/infer_weights_from_file_size.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "cmd_arguments.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+void infer_weights_from_file_size(cmd_arguments & arguments)
+{
+#pragma omp parallel for schedule(static) num_threads(arguments.threads)
+    for (size_t i = 0; i < arguments.number_of_bins; ++i)
+    {
+        arguments.number_of_reads_per_bin[i] = std::filesystem::file_size(arguments.bin_path[i]);
+    }
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/infer_weights_from_hll_sketches.cpp
+++ b/util/applications/src/iScience/generate_reads/infer_weights_from_hll_sketches.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <hibf/sketch/compute_sketches.hpp>
+#include <hibf/sketch/hyperloglog.hpp>
+
+#include <raptor/file_reader.hpp>
+
+#include "cmd_arguments.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+void infer_weights_from_hll_sketches(cmd_arguments & arguments)
+{
+    auto input_fn = [&arguments](size_t const ub_id, seqan::hibf::insert_iterator it)
+    {
+        static raptor::file_reader<raptor::file_types::sequence> const reader{seqan3::ungapped{32u}, 32u};
+        reader.hash_into(arguments.bin_path[ub_id], it);
+    };
+
+    seqan::hibf::config config{.input_fn = input_fn,
+                               .number_of_user_bins = arguments.number_of_bins,
+                               .threads = arguments.threads,
+                               .sketch_bits = 12};
+
+    std::vector<seqan::hibf::sketch::hyperloglog> hyperloglog_sketches;
+    seqan::hibf::sketch::compute_sketches(config, hyperloglog_sketches);
+
+    assert(hyperloglog_sketches.size() == arguments.number_of_bins);
+
+#pragma omp parallel for schedule(static) num_threads(arguments.threads)
+    for (size_t i = 0; i < arguments.number_of_bins; ++i)
+    {
+        arguments.number_of_reads_per_bin[i] = hyperloglog_sketches[i].estimate();
+    }
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/infer_weights_from_kmer_counts.cpp
+++ b/util/applications/src/iScience/generate_reads/infer_weights_from_kmer_counts.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <hibf/contrib/robin_hood.hpp>
+
+#include <raptor/file_reader.hpp>
+
+#include "cmd_arguments.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+void infer_weights_from_kmer_counts(cmd_arguments & arguments)
+{
+    raptor::file_reader<raptor::file_types::sequence> const reader{seqan3::ungapped{32u}, 32u};
+
+#pragma omp parallel for schedule(dynamic) num_threads(arguments.threads)
+    for (size_t i = 0; i < arguments.number_of_bins; ++i)
+    {
+        // could also be defined outside the loop and then be used with the pragma directtive `private(kmer_set)`
+        // and then be cleared at the end of the loop
+        // However, this would increase the maximum memory usage, as the set would stay at the maximum size of all
+        // bins that are processed by this thread.
+        robin_hood::unordered_flat_set<uint64_t> kmer_set{};
+        reader.hash_into(arguments.bin_path[i], std::inserter(kmer_set, kmer_set.begin()));
+        arguments.number_of_reads_per_bin[i] = kmer_set.size();
+    }
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/infer_weights_from_uniform_distribution.cpp
+++ b/util/applications/src/iScience/generate_reads/infer_weights_from_uniform_distribution.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <algorithm>
+
+#include "cmd_arguments.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+void infer_weights_from_uniform_distribution(cmd_arguments & arguments)
+{
+    std::ranges::fill(arguments.number_of_reads_per_bin, arguments.number_of_reads);
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/initialise_argument_parser.cpp
+++ b/util/applications/src/iScience/generate_reads/initialise_argument_parser.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <sharg/all.hpp>
+
+#include <raptor/argument_parsing/validators.hpp>
+
+#include "cmd_arguments.hpp"
+
+namespace sharg::custom
+{
+
+template <>
+struct parsing<raptor::util::generate_reads::weight>
+{
+    static inline std::unordered_map<std::string_view, raptor::util::generate_reads::weight> const enumeration_names{
+        {"from_file_sizes", raptor::util::generate_reads::weight::from_file_sizes},
+        {"from_hll_sketches", raptor::util::generate_reads::weight::from_hll_sketches},
+        {"from_kmer_counts", raptor::util::generate_reads::weight::from_kmer_counts},
+        {"from_weight_column", raptor::util::generate_reads::weight::from_weight_column},
+        {"from_uniform_distribution", raptor::util::generate_reads::weight::from_uniform_distribution}};
+};
+
+} // namespace sharg::custom
+
+namespace raptor::util::generate_reads
+{
+
+class read_output_validator
+{
+private:
+    static inline std::vector<std::string> fasta_fastq_extensions = []()
+    {
+        auto extensions = seqan3::format_fasta::file_extensions;
+        std::ranges::copy(seqan3::format_fastq::file_extensions, std::back_inserter(extensions));
+        return extensions;
+    }();
+
+    // Duplicated because static initialization order is not guaranteed.
+    // raptor::detail::compression_extensions might not be initialized yet.
+    static inline std::vector<std::string> compression_extensions{[]()
+                                                                  {
+                                                                      std::vector<std::string> result;
+#ifdef SEQAN3_HAS_BZIP2
+                                                                      result.push_back("bz2");
+#endif
+#ifdef SEQAN3_HAS_ZLIB
+                                                                      result.push_back("gz");
+                                                                      result.push_back("bgzf");
+#endif
+                                                                      return result;
+                                                                  }()}; // GCOVR_EXCL_LINE
+
+    static inline std::vector<std::string> combined_extensions{
+        []()
+        {
+            if (compression_extensions.empty())
+                return fasta_fastq_extensions; // GCOVR_EXCL_LINE
+            std::vector<std::string> result;
+            for (auto const & sequence_extension : fasta_fastq_extensions)
+            {
+                result.push_back(sequence_extension);
+                for (auto const & compression_extension : compression_extensions)
+                    result.push_back(sequence_extension + std::string{'.'} + compression_extension);
+            }
+            return result;
+        }()};
+
+public:
+    using option_value_type = std::string;
+
+    read_output_validator() = default;
+    read_output_validator(read_output_validator const &) = default;
+    read_output_validator & operator=(read_output_validator const &) = default;
+    read_output_validator(read_output_validator &&) = default;
+    read_output_validator & operator=(read_output_validator &&) = default;
+    ~read_output_validator() = default;
+
+    void operator()(option_value_type const & value) const
+    {
+        std::filesystem::path const out_path{value};
+        std::filesystem::path const out_dir{out_path.parent_path()};
+        if (!out_dir.empty())
+        {
+            std::error_code ec{};
+            std::filesystem::create_directories(out_dir, ec);
+            if (ec)
+                throw sharg::validation_error{
+                    sharg::detail::to_string("Failed to create directory \"", out_dir.c_str(), "\": ", ec.message())};
+        }
+
+        validator(out_path);
+    }
+
+    std::string get_help_page_message() const
+    {
+        return sharg::detail::to_string("Write permissions must be granted. Valid file extensions are ",
+                                        fasta_fastq_extensions,
+#if defined(SEQAN3_HAS_BZIP2) || defined(SEQAN3_HAS_ZLIB)
+                                        ", possibly followed by ",
+                                        raptor::detail::compression_extensions,
+#endif
+                                        ". ");
+    }
+
+private:
+    sharg::output_file_validator validator{sharg::output_file_open_options::open_or_create, combined_extensions};
+};
+
+void initialise_argument_parser(sharg::parser & parser, cmd_arguments & arguments)
+{
+    parser.info.author = "Enrico Seiler";
+    parser.info.author = "enrico.seiler@fu-berlin.de";
+    parser.info.short_description = "Simulate reads from bins";
+    parser.info.description.emplace_back("This utility can be used to simulate reads from bins.");
+    parser.info.description.emplace_back("The number of reads simulated is controlled by weights. "
+                                         "There are several ways to infer weights:");
+    parser.info.description.emplace_back("1. From file sizes: The number of reads per bin is "
+                                         "proportional to the size of the respectice bin file.");
+    parser.info.description.emplace_back("2. [Default] From HLL sketches: The number of reads per bin is "
+                                         "proportional to the HyperLogLog estimate for the respective bin. Canonical "
+                                         "32-mers are used to create the sketch.");
+    parser.info.description.emplace_back("3. From k-mer counts: The number of reads per bin is "
+                                         "proportional to the number of canonical 32-mers in the respective bin. This "
+                                         "approach may have a high memory consumption.");
+    parser.info.description.emplace_back("4. From a weight column in the input file: The number of reads per bin is "
+                                         "proportional to the weights specified in the input file.");
+    parser.info.description.emplace_back("5. From a uniform distribution: The number of reads is equally distributed "
+                                         "across all bins.");
+    parser.info.version = "0.0.1";
+    parser.info.examples = {"generate_reads --input weights.txt --weights from_uniform_distribution --output "
+                            "reads.fasta --errors 2 --read_length 250 --number_of_reads 100000 --threads 4 "
+                            "--print_weights"};
+
+    parser.add_option(
+        arguments.bin_file_path,
+        sharg::config{
+            .short_id = '\0',
+            .long_id = "input",
+            .description =
+                "A file containing file names, one per line. If `--weights from_weight_column` is used, each line must "
+                "additionally contain a weight (integer) after the file name. File name and weight must be separated "
+                "by a tab. If any other weight mode is used, the weight column is ignored and may not even be present.",
+            .required = true,
+            .validator = sharg::input_file_validator{}});
+    parser.add_list_item("", "Example file without weights:");
+    parser.add_list_item("", "```");
+    parser.add_list_item("", "/absolute/path/to/file1.fasta");
+    parser.add_list_item("", "/absolute/path/to/file2.fa.gz");
+    parser.add_list_item("", "```");
+    parser.add_list_item("", "Example file with weights, note that column separator is a tab:");
+    parser.add_list_item("", "```");
+    parser.add_list_item("", "/absolute/path/to/file1.fasta\t27");
+    parser.add_list_item("", "/absolute/path/to/file2.fa.gz\t78");
+    parser.add_list_item("", "```");
+    parser.add_option(arguments.weight_mode,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "weights",
+                                    .description = "How to infer weights.",
+                                    .validator = sharg::value_list_validator{
+                                        std::views::values(sharg::custom::parsing<weight>::enumeration_names)}});
+    parser.add_option(arguments.output_filename,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "output",
+                                    .description = "Where to write the simulated reads",
+                                    .required = true,
+                                    .validator = read_output_validator{}});
+    parser.add_list_item("",
+                         "Using FASTA extensions will create a FASTA file (reads only), while FASTQ extensions will "
+                         "create a FASTQ file (reads and quality). The quality is always set to the maximum value.");
+    parser.add_option(arguments.errors,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "errors",
+                                    .description = "The number of errors.",
+                                    .validator = raptor::positive_integer_validator{true}});
+    parser.add_option(arguments.read_length,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "read_length",
+                                    .description = "The read length.",
+                                    .validator = raptor::positive_integer_validator{}});
+    parser.add_option(arguments.number_of_reads,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "number_of_reads",
+                                    .description = "The number of reads.",
+                                    .validator = raptor::positive_integer_validator{}});
+    parser.add_option(arguments.threads,
+                      sharg::config{.short_id = '\0',
+                                    .long_id = "threads",
+                                    .description = "Number of threads to use.",
+                                    .validator = raptor::positive_integer_validator{}});
+    parser.add_flag(arguments.print_weights,
+                    sharg::config{.short_id = '\0',
+                                  .long_id = "print_weights",
+                                  .description = "Print weights and read counts for each bin."});
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/parse_input.cpp
+++ b/util/applications/src/iScience/generate_reads/parse_input.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <tuple>
+
+#include <sharg/exceptions.hpp>
+#include <sharg/validators.hpp>
+
+#include "cmd_arguments.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+void parse_input(cmd_arguments & arguments)
+{
+    std::ifstream istrm{arguments.bin_file_path};
+    std::string line;
+    sharg::input_file_validator validator{};
+    std::filesystem::path bin_path{};
+
+    while (std::getline(istrm, line))
+    {
+        if (line.empty())
+            continue;
+
+        auto const & [path_span, weight_span] = [&line]()
+        {
+            auto const tab = std::ranges::find(line, '\t');
+            auto const end = line.end();
+
+            std::span path_span{line.begin(), tab};
+            std::span weight_span{std::ranges::next(tab, 1, end), end};
+
+            return std::make_tuple(path_span, weight_span);
+        }();
+
+        bin_path.assign(path_span.begin(), path_span.end());
+        validator(bin_path);
+        arguments.bin_path.push_back(bin_path);
+        ++arguments.number_of_bins;
+
+        if (arguments.weight_mode != weight::from_weight_column)
+            continue;
+
+        if (!weight_span.empty())
+        {
+            arguments.number_of_reads_per_bin.emplace_back();
+            std::from_chars(weight_span.data(),
+                            weight_span.data() + weight_span.size(),
+                            arguments.number_of_reads_per_bin.back());
+        }
+        else
+        {
+            throw sharg::parser_error{"No weight given for bin: " + bin_path.string()};
+        }
+    }
+
+    if (arguments.weight_mode != weight::from_weight_column)
+        arguments.number_of_reads_per_bin.resize(arguments.number_of_bins);
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/print_weights.cpp
+++ b/util/applications/src/iScience/generate_reads/print_weights.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <string_view>
+#include <vector>
+
+namespace raptor::util::generate_reads
+{
+
+void print_weights(std::vector<size_t> const & vec, std::string_view const first_line)
+{
+    std::cout << '\n' << first_line << '\n';
+    for (size_t i = 0; i < vec.size(); ++i)
+        std::cout << vec[i] << ' ';
+    std::cout << '\n';
+
+    auto const sum_of_weights = std::reduce(vec.begin(), vec.end());
+    std::cout << "  Sum: " << sum_of_weights << '\n';
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/seqan3_sequence_io.hpp
+++ b/util/applications/src/iScience/generate_reads/seqan3_sequence_io.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <seqan3/io/sequence_file/input.hpp>
+#include <seqan3/io/sequence_file/output.hpp>
+
+namespace raptor::util::generate_reads
+{
+
+struct char_traits : seqan3::sequence_file_input_default_traits_dna
+{
+    using sequence_alphabet = char;
+    using sequence_legal_alphabet = char;
+};
+
+struct dna4_traits : seqan3::sequence_file_input_default_traits_dna
+{
+    using sequence_alphabet = seqan3::dna4;
+};
+
+size_t count_records_in_fasta(std::filesystem::path const & filename)
+{
+    seqan3::sequence_file_input<char_traits, seqan3::fields<seqan3::field::id>> fin{filename};
+    return std::ranges::distance(fin);
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads/simulate_reads.cpp
+++ b/util/applications/src/iScience/generate_reads/simulate_reads.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <random>
+
+#include <seqan3/io/sequence_file/input.hpp>
+#include <seqan3/io/sequence_file/output.hpp>
+
+#include <hibf/misc/divide_and_ceil.hpp>
+
+#include "cmd_arguments.hpp"
+#include "seqan3_sequence_io.hpp"
+
+namespace raptor::util::generate_reads
+{
+
+size_t simulate_reads(cmd_arguments const & arguments)
+{
+    using input_file_t = seqan3::sequence_file_input<dna4_traits, seqan3::fields<seqan3::field::seq>>;
+    std::vector<seqan3::phred42> const quality(arguments.read_length, seqan3::assign_rank_to(40u, seqan3::phred42{}));
+    seqan3::sequence_file_output fout{arguments.output_filename};
+
+    std::uniform_int_distribution<size_t> read_error_position_dis(0u, arguments.read_length - 1u);
+    std::uniform_int_distribution<uint8_t> dna4_rank_dis(0u, 3u);
+
+    size_t total_reads{};
+
+#pragma omp parallel for schedule(dynamic) num_threads(arguments.threads)
+    for (size_t bin_number = 0; bin_number < arguments.bin_path.size(); ++bin_number)
+    {
+        std::mt19937_64 rng{bin_number};
+
+        auto const & bin_file = arguments.bin_path[bin_number];
+
+        size_t const number_of_records{count_records_in_fasta(bin_file)};
+        size_t const reads_per_record =
+            seqan::hibf::divide_and_ceil(arguments.number_of_reads_per_bin[bin_number], number_of_records);
+
+        std::vector<std::vector<seqan3::dna4>> reads(reads_per_record * number_of_records);
+
+        size_t read_counter{};
+
+        for (auto const & [seq] : input_file_t{bin_file})
+        {
+            size_t const reference_length = std::ranges::size(seq);
+            if (reference_length < arguments.read_length)
+                continue;
+            std::uniform_int_distribution<size_t> read_start_dis(0u, reference_length - arguments.read_length);
+
+            for (size_t read_number = 0u; read_number < reads_per_record; ++read_number, ++read_counter)
+            {
+                auto & read = reads[read_counter];
+                size_t const read_start_pos = read_start_dis(rng);
+                auto read_span = std::span{seq.data() + read_start_pos, arguments.read_length};
+                read.assign(read_span.begin(), read_span.end());
+
+                for (uint8_t error_count = 0; error_count < arguments.errors; ++error_count)
+                {
+                    size_t const error_pos = read_error_position_dis(rng);
+                    seqan3::dna4 const current_base = read[error_pos];
+                    seqan3::dna4 new_base = current_base;
+                    while (new_base == current_base)
+                        seqan3::assign_rank_to(dna4_rank_dis(rng), new_base);
+                    read[error_pos] = new_base;
+                }
+            }
+        }
+
+        std::string const bin_filename = bin_file.filename();
+
+#pragma omp critical
+        {
+            total_reads += read_counter;
+            for (size_t read_number = 0u; read_number < read_counter; ++read_number)
+            {
+                fout.emplace_back(reads[read_number], bin_filename + "_" + std::to_string(read_number), quality);
+            }
+        }
+    }
+
+    return total_reads;
+}
+
+} // namespace raptor::util::generate_reads

--- a/util/applications/src/iScience/generate_reads_refseq.cpp
+++ b/util/applications/src/iScience/generate_reads_refseq.cpp
@@ -2,235 +2,96 @@
 // SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <random>
-
 #include <sharg/all.hpp>
 
-#include <seqan3/core/algorithm/detail/execution_handler_parallel.hpp>
-#include <seqan3/io/sequence_file/input.hpp>
-#include <seqan3/io/sequence_file/output.hpp>
+#include "generate_reads/cmd_arguments.hpp"
 
-#include <hibf/contrib/std/chunk_view.hpp>
-#include <hibf/contrib/std/zip_view.hpp>
-
-struct cmd_arguments
+namespace raptor::util::generate_reads
 {
-    std::filesystem::path bin_file_path{};
-    std::vector<std::filesystem::path> bin_path{};
-    std::filesystem::path output_directory{};
-    uint8_t errors{2u};
-    uint32_t read_length{100u};
-    uint32_t number_of_reads{1ULL << 20};
-    uint64_t threads{1u};
-};
 
-struct char_traits : seqan3::sequence_file_input_default_traits_dna
+void apply_weights(std::vector<size_t> & vec, size_t const number_of_reads);
+void print_weights(std::vector<size_t> const & vec, std::string_view const first_line);
+void infer_weights_from_file_size(cmd_arguments & arguments);
+void infer_weights_from_hll_sketches(cmd_arguments & arguments);
+void infer_weights_from_kmer_counts(cmd_arguments & arguments);
+void infer_weights_from_uniform_distribution(cmd_arguments & arguments);
+void initialise_argument_parser(sharg::parser & parser, cmd_arguments & arguments);
+void parse_input(cmd_arguments & arguments);
+size_t simulate_reads(cmd_arguments const & arguments);
+
+} // namespace raptor::util::generate_reads
+
+namespace raptor::util::generate_reads
 {
-    using sequence_alphabet = char;
-    using sequence_legal_alphabet = char;
-};
 
-struct dna4_traits : seqan3::sequence_file_input_default_traits_dna
+void run(std::vector<std::string> const & cli_arguments)
 {
-    using sequence_alphabet = seqan3::dna4;
-};
-
-class positive_integer_validator
-{
-public:
-    using option_value_type = size_t;
-
-    positive_integer_validator() = default;
-    positive_integer_validator(bool const is_zero_positive_) : is_zero_positive{is_zero_positive_}
-    {}
-
-    void operator()(option_value_type const & val) const
-    {
-        if (!is_zero_positive && !val)
-        {
-            throw sharg::validation_error{"The value must be a positive integer."};
-        }
-    }
-
-    std::string get_help_page_message() const
-    {
-        if (is_zero_positive)
-            return "Value must be a positive integer or 0.";
-        else
-            return "Value must be a positive integer.";
-    }
-
-private:
-    bool is_zero_positive{false};
-};
-
-inline size_t count_records_in_fasta(std::filesystem::path const & filename)
-{
-    seqan3::sequence_file_input<char_traits, seqan3::fields<seqan3::field::id>> fin{filename};
-    return std::ranges::distance(fin);
-}
-
-void run_program(cmd_arguments const & arguments)
-{
-    std::uniform_int_distribution<uint32_t> read_error_position_dis(0, arguments.read_length - 1);
-    std::uniform_int_distribution<uint8_t> dna4_rank_dis(0, 3);
-
-    size_t const number_of_bins{arguments.bin_path.size()};
-    uint32_t const reads_per_bin = arguments.number_of_reads / number_of_bins;
-
-    std::vector<seqan3::phred42> const quality(arguments.read_length, seqan3::assign_rank_to(40u, seqan3::phred42{}));
-
-    auto worker = [&](auto && zipped_view, auto &&)
-    {
-    // https://godbolt.org/z/PeKnxzjn1
-#if defined(__clang__)
-        for (auto && zipped : zipped_view)
-        {
-            auto bin_file = std::move(std::get<0>(zipped));
-            auto bin_number = std::move(std::get<1>(zipped));
-#else
-        for (auto && [bin_file, bin_number] : zipped_view)
-        {
-#endif
-            std::mt19937_64 rng(bin_number);
-            uint32_t read_counter{bin_number * reads_per_bin};
-            // Immediately invoked initialising lambda expession (IIILE).
-            std::filesystem::path const out_file = [&]()
-            {
-                std::filesystem::path out_file = arguments.output_directory;
-                if (bin_file.extension() == ".gz")
-                    out_file /= bin_file.stem().stem();
-                else
-                    out_file /= bin_file.stem();
-                out_file += ".fastq";
-                return out_file;
-            }();
-
-            size_t const number_of_records{count_records_in_fasta(bin_file)};
-            uint32_t const reads_per_record = (reads_per_bin + number_of_records - 1) / number_of_records;
-
-            seqan3::sequence_file_input<dna4_traits, seqan3::fields<seqan3::field::seq>> fin{bin_file};
-            seqan3::sequence_file_output fout{out_file};
-
-            uint16_t bin_read_counter{};
-            std::vector<seqan3::dna4> read;
-
-            for (auto const & [seq] : fin)
-            {
-                uint64_t const reference_length = std::ranges::size(seq);
-                std::uniform_int_distribution<uint64_t> read_start_dis(0, reference_length - arguments.read_length);
-                for (uint32_t current_read_number = 0;
-                     current_read_number < reads_per_record && bin_read_counter < reads_per_bin;
-                     ++current_read_number, ++read_counter, ++bin_read_counter)
-                {
-                    uint64_t const read_start_pos = read_start_dis(rng);
-                    auto read_span = std::span{seq.data() + read_start_pos, arguments.read_length};
-                    read.assign(read_span.begin(), read_span.end());
-
-                    for (uint8_t error_count = 0; error_count < arguments.errors; ++error_count)
-                    {
-                        uint32_t const error_pos = read_error_position_dis(rng);
-                        seqan3::dna4 const current_base = read[error_pos];
-                        seqan3::dna4 new_base = current_base;
-                        while (new_base == current_base)
-                            seqan3::assign_rank_to(dna4_rank_dis(rng), new_base);
-                        read[error_pos] = new_base;
-                    }
-
-                    fout.emplace_back(read, std::to_string(read_counter), quality);
-                }
-            }
-        }
-    };
-
-    size_t const chunk_size = std::bit_ceil(number_of_bins / arguments.threads);
-    auto chunked_view =
-        seqan::stl::views::zip(arguments.bin_path, std::views::iota(0u)) | seqan::stl::views::chunk(chunk_size);
-    seqan3::detail::execution_handler_parallel executioner{arguments.threads};
-    executioner.bulk_execute(std::move(worker), std::move(chunked_view), []() {});
-}
-
-void initialise_argument_parser(sharg::parser & parser, cmd_arguments & arguments)
-{
-    parser.info.author = "Enrico Seiler";
-    parser.info.author = "enrico.seiler@fu-berlin.de";
-    parser.info.short_description = "Generate reads from bins.";
-    parser.info.version = "0.0.1";
-    parser.info.examples = {"./generate_reads_refseq --output ./reads_e2 all_bins.txt"};
-    parser.add_positional_option(
-        arguments.bin_file_path,
-        sharg::config{.description = "Provide a path to a file containing one path to a bin per line.",
-                      .validator = sharg::input_file_validator{}});
-    parser.add_option(arguments.output_directory,
-                      sharg::config{.short_id = '\0',
-                                    .long_id = "output",
-                                    .description = "Provide the base dir where the reads should be written to.",
-                                    .required = true,
-                                    .validator = sharg::output_directory_validator{}});
-    parser.add_option(arguments.errors,
-                      sharg::config{.short_id = '\0',
-                                    .long_id = "errors",
-                                    .description = "The number of errors.",
-                                    .validator = positive_integer_validator{true}});
-    parser.add_option(arguments.read_length,
-                      sharg::config{.short_id = '\0',
-                                    .long_id = "read_length",
-                                    .description = "The read length.",
-                                    .validator = positive_integer_validator{}});
-    parser.add_option(arguments.number_of_reads,
-                      sharg::config{.short_id = '\0',
-                                    .long_id = "number_of_reads",
-                                    .description = "The number of reads.",
-                                    .validator = positive_integer_validator{}});
-    parser.add_option(arguments.threads,
-                      sharg::config{.short_id = '\0',
-                                    .long_id = "threads",
-                                    .description = "Number of threads to use.",
-                                    .validator = positive_integer_validator{}});
-}
-
-int main(int argc, char ** argv)
-{
-    sharg::parser myparser{"build_ibf", argc, argv, sharg::update_notifications::off};
+    sharg::parser parser{"generate_reads", cli_arguments, sharg::update_notifications::off};
     cmd_arguments arguments{};
-    initialise_argument_parser(myparser, arguments);
-    try
+    initialise_argument_parser(parser, arguments);
+    parser.parse();
+
+    parse_input(arguments);
+
+    switch (arguments.weight_mode)
     {
-        myparser.parse();
-    }
-    catch (sharg::parser_error const & ext)
-    {
-        std::cout << "[Error] " << ext.what() << "\n";
-        return -1;
+    case weight::from_hll_sketches:
+        infer_weights_from_hll_sketches(arguments);
+        break;
+    case weight::from_file_sizes:
+        infer_weights_from_file_size(arguments);
+        break;
+    case weight::from_kmer_counts:
+        infer_weights_from_kmer_counts(arguments);
+        break;
+    case weight::from_weight_column:
+        break;
+    case weight::from_uniform_distribution:
+        infer_weights_from_uniform_distribution(arguments);
+        break;
+    default:
+        throw sharg::parser_error{"Unknown weight mode."};
     }
 
-    std::ifstream istrm{arguments.bin_file_path};
-    std::string line;
-    sharg::input_file_validator validator{};
-
-    while (std::getline(istrm, line))
-    {
-        if (!line.empty())
-        {
-            std::filesystem::path bin_path{line};
-            validator(bin_path);
-            arguments.bin_path.push_back(std::move(bin_path));
-        }
-    }
-
-    size_t const number_of_bins{arguments.bin_path.size()};
+    if (arguments.print_weights)
+        print_weights(arguments.number_of_reads_per_bin, "Weights:");
 
     if (arguments.errors > arguments.read_length)
         throw sharg::parser_error{"Cannot have more errors than the read is long."};
 
-    if (number_of_bins > arguments.number_of_reads)
+    if (arguments.number_of_bins > arguments.number_of_reads)
         throw sharg::parser_error{"Must simulate at least one read per bin."};
 
-    if (arguments.number_of_reads % number_of_bins)
-        throw sharg::parser_error{"The number of reads must distribute evenly over the bins."};
+    if (arguments.number_of_bins != arguments.number_of_reads_per_bin.size())
+        throw sharg::parser_error{"arguments.number_of_bins (" + std::to_string(arguments.number_of_bins)
+                                  + " != arguments.number_of_reads_per_bin.size()"
+                                  + std::to_string(arguments.number_of_reads_per_bin.size()) + ")"};
 
-    std::filesystem::create_directory(arguments.output_directory);
-    run_program(arguments);
+    apply_weights(arguments.number_of_reads_per_bin, arguments.number_of_reads);
+
+    if (arguments.print_weights)
+        print_weights(arguments.number_of_reads_per_bin, "Read counts:");
+
+    size_t const total_reads = simulate_reads(arguments);
+
+    std::cout << "\nTotal simulated reads: " << total_reads << '\n';
+}
+
+} // namespace raptor::util::generate_reads
+
+int main(int argc, char ** argv)
+{
+    try
+    {
+        // Use the (user's environment) default locale for output. Usually results in numbers having separators.
+        std::cout.imbue(std::locale(""));
+        raptor::util::generate_reads::run({argv, argv + argc});
+    }
+    catch (sharg::parser_error const & ext)
+    {
+        std::cerr << "[Error] " << ext.what() << '\n';
+        std::exit(-1);
+    }
 
     return 0;
 }


### PR DESCRIPTION
I think I never updated the changes I did to generate reads refseq.

The changes introduced here currently read in a file with weights and then generate a number of reads per bin s.t. large user bins have more reads than small ones.

Followup:
- [x] Instead of reading in weigths, one could maybe use the file sizes directly?