### PR TITLE
[FIX] FPGA: Linkage

### DIFF
--- a/src/search/fpga/CMakeLists.txt
+++ b/src/search/fpga/CMakeLists.txt
@@ -75,7 +75,8 @@ foreach (WINDOW_SIZE IN LISTS WINDOW_SIZE_LIST)
                     generate_target ("" DEVICE_TARGET)
                     add_library (${DEVICE_TARGET} SHARED "${ibf-fpga_SOURCE_DIR}/src/fpga_device.cpp")
                     add_common_target_options (${DEVICE_TARGET})
-                    target_link_libraries (raptor_search_fpga PRIVATE ${DEVICE_TARGET})
+                    add_dependencies (raptor_search_fpga ${DEVICE_TARGET})
+                    target_link_directories (raptor_search_fpga PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
                     # For hardware only
                     if (RAPTOR_FPGA_HARDWARE)
                         ## Report

--- a/test/unit/cli/search/search_ibf_fpga_test.cpp
+++ b/test/unit/cli/search/search_ibf_fpga_test.cpp
@@ -4,7 +4,6 @@
 
 #include <raptor/test/cli_test.hpp>
 
-// Todo 128 bins (32 in test suite at the end) does currently not work
 // Same as search_ibf_test.cpp, but
 // * `--fpga` as option
 // * Expection result.err to be non-empty (profiling)
@@ -64,7 +63,7 @@ TEST_P(search_ibf_fpga, no_hits)
 
 INSTANTIATE_TEST_SUITE_P(search_ibf_fpga_suite,
                          search_ibf_fpga,
-                         testing::Combine(testing::Values(16 /*, 32*/), testing::Values(23), testing::Values(0, 1)),
+                         testing::Combine(testing::Values(16, 32), testing::Values(23), testing::Values(0, 1)),
                          [](testing::TestParamInfo<search_ibf_fpga::ParamType> const & info)
                          {
                              std::string name = std::to_string(std::max<int>(1, std::get<0>(info.param) * 4)) + "_bins_"


### PR DESCRIPTION
Linking causes problems due to ODR. Use target_link_directories to still get the RPATH