### PR TITLE
fix: move intelllvm workaround

### DIFF
--- a/cmake/configuration.cmake
+++ b/cmake/configuration.cmake
@@ -97,6 +97,11 @@ add_library (raptor_interface INTERFACE)
 target_link_libraries (raptor_interface INTERFACE sharg::sharg seqan3::seqan3 seqan::hibf)
 target_include_directories (raptor_interface INTERFACE "${RAPTOR_INCLUDE_DIR}")
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+    # "invalid feature combination:  +avx10.1-256; will be promoted to avx10.1-512"
+    target_compile_options (raptor_interface INTERFACE "-Wno-invalid-feature-combination")
+endif ()
+
 get_target_property (CHOPPER_INCLUDE_DIR chopper::interface INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories (raptor_interface SYSTEM INTERFACE "${CHOPPER_INCLUDE_DIR}")
 

--- a/test/raptor-test.cmake
+++ b/test/raptor-test.cmake
@@ -24,6 +24,12 @@ include ("${Raptor_SOURCE_DIR}/cmake/configuration.cmake")
 add_subdirectory ("${Raptor_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/raptor")
 target_compile_options (raptor_interface INTERFACE "-pedantic" "-Wall" "-Wextra")
 
+# Re-add to ensure it overrides `-Wall`.
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+    # "invalid feature combination:  +avx10.1-256; will be promoted to avx10.1-512"
+    target_compile_options (raptor_interface INTERFACE "-Wno-invalid-feature-combination")
+endif ()
+
 option (RAPTOR_WITH_WERROR "Report compiler warnings as errors." ON)
 
 if (RAPTOR_WITH_WERROR)
@@ -77,11 +83,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
         target_compile_definitions (raptor_test INTERFACE "_LIBCPP_ENABLE_EXPERIMENTAL")
     endif ()
-endif ()
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
-    # "invalid feature combination:  +avx10.1-256; will be promoted to avx10.1-512"
-    target_compile_options (raptor_interface INTERFACE "-Wno-invalid-feature-combination")
 endif ()
 
 target_link_libraries (raptor_test INTERFACE "raptor_lib")


### PR DESCRIPTION
Also needs to be in `cmake/configuration.cmake` for the `util/applications` include